### PR TITLE
Add setup script with pnpm install

### DIFF
--- a/.conductor/setup.sh
+++ b/.conductor/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+pnpm install


### PR DESCRIPTION
Adds a `.conductor/setup.sh` script that automatically installs dependencies when new workspaces are created. This ensures developers have all required packages without manual setup.