### PR TITLE
Implement Skills Scanner

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1766,6 +1766,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -1776,6 +1777,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 0.8.2",
+ "walkdir",
 ]
 
 [[package]]
@@ -2885,6 +2887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,6 +3116,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4165,6 +4186,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,8 @@ tauri-plugin-store = "2"
 dirs = "6"
 thiserror = "2"
 toml = "0.8"
+serde_yaml = "0.9"
+walkdir = "2"
 tokio = { version = "1", features = ["fs", "process", "time"] }
 
 [dev-dependencies]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,5 @@
 pub mod mcps;
+pub mod skills;
 
 pub use mcps::*;
+pub use skills::*;

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1,0 +1,9 @@
+//! Tauri commands for Skills management
+
+use crate::scanners::skills::{scan_all_skills, SkillScanResult};
+
+/// Scan all skills from Claude Code, Codex CLI, and Gemini CLI
+#[tauri::command]
+pub fn scan_skills(workspace_path: Option<String>) -> Result<SkillScanResult, String> {
+    scan_all_skills(workspace_path.as_deref())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ mod parsers;
 mod scanners;
 mod workspace;
 
-use commands::scan_mcps;
+use commands::{scan_mcps, scan_skills};
 
 #[derive(Debug, Error)]
 pub enum LoadoutError {
@@ -90,6 +90,7 @@ pub fn run() {
             get_workspace_info,
             get_home_dir,
             scan_mcps,
+            scan_skills,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/parsers/mod.rs
+++ b/src-tauri/src/parsers/mod.rs
@@ -1,5 +1,7 @@
 pub mod json_config;
+pub mod skill_md;
 pub mod toml_config;
 
 pub use json_config::*;
+pub use skill_md::*;
 pub use toml_config::*;

--- a/src-tauri/src/parsers/skill_md.rs
+++ b/src-tauri/src/parsers/skill_md.rs
@@ -1,0 +1,188 @@
+//! Parser for SKILL.md files (Open Agent Skills Standard)
+//!
+//! Skills use YAML frontmatter for metadata and markdown for content:
+//! ```markdown
+//! ---
+//! name: skill-name
+//! description: When to use this skill
+//! metadata:
+//!   short-description: Optional user-facing description
+//! ---
+//!
+//! ## Instructions
+//! Your skill content here...
+//! ```
+
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+/// Metadata section in SKILL.md frontmatter
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct SkillMetadata {
+    pub short_description: Option<String>,
+}
+
+/// Parsed skill from a SKILL.md file
+#[derive(Debug, Clone)]
+pub struct ParsedSkill {
+    pub name: String,
+    pub description: String,
+    pub metadata: Option<SkillMetadata>,
+    pub content: String,
+}
+
+/// YAML frontmatter structure
+#[derive(Debug, Deserialize)]
+struct SkillFrontmatter {
+    name: String,
+    description: String,
+    #[serde(default)]
+    metadata: Option<SkillMetadata>,
+}
+
+/// Parse a SKILL.md file and extract frontmatter + content.
+/// Falls back to directory name and first meaningful line if no frontmatter is present.
+pub fn parse_skill_md(path: &Path) -> Result<ParsedSkill, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+
+    // Derive fallback name from parent directory (e.g., "verify-work" from ".../verify-work/SKILL.md")
+    let fallback_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    parse_skill_content(&content, &fallback_name)
+}
+
+/// Parse skill content string (separated for testing).
+/// Tries YAML frontmatter first, falls back to plain markdown.
+pub fn parse_skill_content(content: &str, fallback_name: &str) -> Result<ParsedSkill, String> {
+    let content = content.trim();
+
+    // Try parsing with YAML frontmatter first
+    if content.starts_with("---") {
+        if let Some(result) = try_parse_frontmatter(content) {
+            return Ok(result);
+        }
+    }
+
+    // Fallback: treat as plain markdown
+    parse_plain_markdown(content, fallback_name)
+}
+
+/// Try to parse content with YAML frontmatter, returns None on failure
+fn try_parse_frontmatter(content: &str) -> Option<ParsedSkill> {
+    let after_first_delimiter = &content[3..];
+    let end_pos = after_first_delimiter.find("\n---")?;
+
+    let frontmatter_str = after_first_delimiter[..end_pos].trim();
+    let markdown_content = after_first_delimiter[end_pos + 4..].trim();
+
+    let frontmatter: SkillFrontmatter = serde_yaml::from_str(frontmatter_str).ok()?;
+
+    Some(ParsedSkill {
+        name: frontmatter.name,
+        description: frontmatter.description,
+        metadata: frontmatter.metadata,
+        content: markdown_content.to_string(),
+    })
+}
+
+/// Parse a plain markdown SKILL.md without frontmatter.
+/// Uses the directory name as skill name and extracts the first meaningful
+/// non-heading line as description.
+fn parse_plain_markdown(content: &str, fallback_name: &str) -> Result<ParsedSkill, String> {
+    let mut description = String::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        // Strip bold markers for cleaner description
+        description = trimmed.replace("**", "");
+        break;
+    }
+
+    if description.is_empty() {
+        description = format!("Skill from {}", fallback_name);
+    }
+
+    // Truncate long descriptions
+    if description.len() > 120 {
+        description = format!("{}...", &description[..117]);
+    }
+
+    Ok(ParsedSkill {
+        name: fallback_name.to_string(),
+        description,
+        metadata: None,
+        content: content.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_basic_skill() {
+        let content = r#"---
+name: test-skill
+description: A test skill for unit tests
+---
+
+## Instructions
+This is the skill content.
+"#;
+        let skill = parse_skill_content(content, "test-skill").unwrap();
+        assert_eq!(skill.name, "test-skill");
+        assert_eq!(skill.description, "A test skill for unit tests");
+        assert!(skill.content.contains("## Instructions"));
+        assert!(skill.content.contains("This is the skill content."));
+    }
+
+    #[test]
+    fn test_parse_skill_with_metadata() {
+        let content = r#"---
+name: fancy-skill
+description: A skill with metadata
+metadata:
+  short-description: Fancy short desc
+---
+
+Content here.
+"#;
+        let skill = parse_skill_content(content, "fancy-skill").unwrap();
+        assert_eq!(skill.name, "fancy-skill");
+        assert!(skill.metadata.is_some());
+        assert_eq!(
+            skill.metadata.unwrap().short_description,
+            Some("Fancy short desc".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_no_frontmatter_uses_fallback() {
+        let content = "# Verify Work Skill\n\n**IMPORTANT: Only use this skill when requested.**\n\nDo the work.";
+        let skill = parse_skill_content(content, "verify-work").unwrap();
+        assert_eq!(skill.name, "verify-work");
+        assert_eq!(skill.description, "IMPORTANT: Only use this skill when requested.");
+        assert!(skill.content.contains("# Verify Work Skill"));
+    }
+
+    #[test]
+    fn test_parse_unclosed_frontmatter_falls_back() {
+        let content = r#"---
+name: broken
+description: Missing closing delimiter
+"#;
+        // Falls back to plain markdown parsing with the fallback name
+        let skill = parse_skill_content(content, "broken-skill").unwrap();
+        assert_eq!(skill.name, "broken-skill");
+    }
+}

--- a/src-tauri/src/scanners/mod.rs
+++ b/src-tauri/src/scanners/mod.rs
@@ -1,3 +1,2 @@
 pub mod mcps;
-
-pub use mcps::*;
+pub mod skills;

--- a/src-tauri/src/scanners/skills.rs
+++ b/src-tauri/src/scanners/skills.rs
@@ -1,0 +1,417 @@
+//! Skills scanner for Claude Code, Codex CLI, and Gemini CLI
+//!
+//! Scans all skill paths and returns a unified list with maturity badges,
+//! conflict detection, and shadowing information.
+
+use crate::parsers::parse_skill_md;
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use walkdir::WalkDir;
+
+/// Source tool for a skill
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillSourceTool {
+    Claude,
+    Codex,
+    Gemini,
+}
+
+/// Scope of a skill (user-level or project-level)
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillScope {
+    User,
+    Project,
+}
+
+/// Maturity level of a skill feature
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillMaturity {
+    Stable,
+    Experimental,
+}
+
+/// Normalized skill item for the frontend
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillItem {
+    /// Unique identifier (hash of name + source + scope)
+    pub id: String,
+    /// Skill name from frontmatter
+    pub name: String,
+    /// Skill description from frontmatter
+    pub description: String,
+    /// Full markdown content
+    pub content: String,
+    /// Which tool this skill is from
+    pub source_tool: SkillSourceTool,
+    /// Scope level (user or project)
+    pub scope: SkillScope,
+    /// Feature maturity (stable or experimental)
+    pub maturity: SkillMaturity,
+    /// Absolute path to the SKILL.md file
+    pub path: String,
+    /// True if this skill is shadowed by a higher-precedence skill
+    pub is_shadowed: bool,
+    /// Path of the skill that shadows this one
+    pub shadowed_by: Option<String>,
+}
+
+/// Conflict information when same skill name has different content
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillConflict {
+    /// Skill name that has conflicts
+    pub name: String,
+    /// Paths of skills with different content
+    pub conflicting_paths: Vec<String>,
+    /// Tools that have this conflict
+    pub tools: Vec<SkillSourceTool>,
+}
+
+/// Result of scanning all skills
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillScanResult {
+    /// All discovered skills
+    pub skills: Vec<SkillItem>,
+    /// Detected conflicts (same name, different content)
+    pub conflicts: Vec<SkillConflict>,
+}
+
+/// Internal struct for tracking skill during scanning
+#[derive(Debug, Clone)]
+struct RawSkillEntry {
+    name: String,
+    description: String,
+    content: String,
+    content_hash: u64,
+    source_tool: SkillSourceTool,
+    scope: SkillScope,
+    path: String,
+}
+
+/// Scan all skills across all tools
+pub fn scan_all_skills(workspace_path: Option<&str>) -> Result<SkillScanResult, String> {
+    let home_dir = dirs::home_dir().ok_or("Could not determine home directory")?;
+    let mut entries: Vec<RawSkillEntry> = Vec::new();
+
+    // Scan Claude Code skills
+    // User-level: ~/.claude/skills/<name>/SKILL.md
+    let claude_user_path = home_dir.join(".claude").join("skills");
+    scan_skill_directory(&claude_user_path, SkillSourceTool::Claude, SkillScope::User, &mut entries);
+
+    // Project-level: $PROJECT_ROOT/.claude/skills/<name>/SKILL.md
+    if let Some(ws_path) = workspace_path {
+        let claude_project_path = PathBuf::from(ws_path).join(".claude").join("skills");
+        scan_skill_directory(&claude_project_path, SkillSourceTool::Claude, SkillScope::Project, &mut entries);
+    }
+
+    // Scan Codex CLI skills
+    // User-level: $HOME/.agents/skills/<name>/SKILL.md
+    let codex_user_path = home_dir.join(".agents").join("skills");
+    scan_skill_directory(&codex_user_path, SkillSourceTool::Codex, SkillScope::User, &mut entries);
+
+    // Project-level: $PROJECT_ROOT/.codex/skills/<name>/SKILL.md
+    if let Some(ws_path) = workspace_path {
+        let codex_project_path = PathBuf::from(ws_path).join(".codex").join("skills");
+        scan_skill_directory(&codex_project_path, SkillSourceTool::Codex, SkillScope::Project, &mut entries);
+    }
+
+    // Scan Gemini CLI skills
+    // User-level: ~/.gemini/skills/<name>/SKILL.md
+    let gemini_user_path = home_dir.join(".gemini").join("skills");
+    scan_skill_directory(&gemini_user_path, SkillSourceTool::Gemini, SkillScope::User, &mut entries);
+
+    // Project-level: $PROJECT_ROOT/.gemini/skills/<name>/SKILL.md
+    if let Some(ws_path) = workspace_path {
+        let gemini_project_path = PathBuf::from(ws_path).join(".gemini").join("skills");
+        scan_skill_directory(&gemini_project_path, SkillSourceTool::Gemini, SkillScope::Project, &mut entries);
+    }
+
+    // Process entries: detect conflicts and shadowing
+    let (skills, conflicts) = process_skill_entries(entries);
+
+    Ok(SkillScanResult { skills, conflicts })
+}
+
+/// Scan a directory for SKILL.md files
+fn scan_skill_directory(
+    base_path: &PathBuf,
+    source_tool: SkillSourceTool,
+    scope: SkillScope,
+    entries: &mut Vec<RawSkillEntry>,
+) {
+    if !base_path.exists() {
+        return;
+    }
+
+    // Walk the directory looking for SKILL.md files
+    for entry in WalkDir::new(base_path)
+        .min_depth(2)
+        .max_depth(2)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if path.file_name().map(|n| n == "SKILL.md").unwrap_or(false) {
+            if let Ok(skill) = parse_skill_md(path) {
+                let content_hash = hash_content(&skill.content);
+                entries.push(RawSkillEntry {
+                    name: skill.name,
+                    description: skill.description,
+                    content: skill.content,
+                    content_hash,
+                    source_tool,
+                    scope,
+                    path: path.to_string_lossy().to_string(),
+                });
+            }
+        }
+    }
+}
+
+/// Hash content for comparison
+fn hash_content(content: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    content.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Generate a unique ID for a skill
+fn generate_skill_id(name: &str, source_tool: SkillSourceTool, scope: SkillScope) -> String {
+    let mut hasher = DefaultHasher::new();
+    name.hash(&mut hasher);
+    format!("{:?}", source_tool).hash(&mut hasher);
+    format!("{:?}", scope).hash(&mut hasher);
+    format!("skill_{:x}", hasher.finish())
+}
+
+/// Process entries to detect conflicts and shadowing
+fn process_skill_entries(entries: Vec<RawSkillEntry>) -> (Vec<SkillItem>, Vec<SkillConflict>) {
+    let mut skills: Vec<SkillItem> = Vec::new();
+    let mut conflicts: Vec<SkillConflict> = Vec::new();
+
+    // Group by name to detect conflicts and shadowing
+    let mut by_name: HashMap<String, Vec<&RawSkillEntry>> = HashMap::new();
+    for entry in &entries {
+        by_name.entry(entry.name.clone()).or_default().push(entry);
+    }
+
+    // Track which skills shadow others (within same tool)
+    // For Codex: project > user
+    // Key: (name, tool) -> shadowing path
+    let mut shadow_map: HashMap<(String, SkillSourceTool), String> = HashMap::new();
+
+    // First pass: determine shadowing within same tool
+    for (name, group) in &by_name {
+        for tool in [SkillSourceTool::Claude, SkillSourceTool::Codex, SkillSourceTool::Gemini] {
+            let tool_skills: Vec<_> = group.iter().filter(|e| e.source_tool == tool).collect();
+
+            // If both project and user exist for same tool, project shadows user
+            let project_skill = tool_skills.iter().find(|e| e.scope == SkillScope::Project);
+            let user_skill = tool_skills.iter().find(|e| e.scope == SkillScope::User);
+
+            if let (Some(proj), Some(_user)) = (project_skill, user_skill) {
+                shadow_map.insert((name.clone(), tool), proj.path.clone());
+            }
+        }
+    }
+
+    // Second pass: detect conflicts (same name, different content across tools)
+    for (name, group) in &by_name {
+        // Check if there are different content hashes
+        let unique_hashes: std::collections::HashSet<u64> = group.iter().map(|e| e.content_hash).collect();
+
+        if unique_hashes.len() > 1 {
+            // There's a conflict - different content for same skill name
+            let conflicting_paths: Vec<String> = group.iter().map(|e| e.path.clone()).collect();
+            let tools: Vec<SkillSourceTool> = group.iter().map(|e| e.source_tool).collect::<std::collections::HashSet<_>>().into_iter().collect();
+
+            conflicts.push(SkillConflict {
+                name: name.clone(),
+                conflicting_paths,
+                tools,
+            });
+        }
+    }
+
+    // Third pass: build final skill items
+    for entry in entries {
+        let maturity = match entry.source_tool {
+            SkillSourceTool::Claude | SkillSourceTool::Codex => SkillMaturity::Stable,
+            SkillSourceTool::Gemini => SkillMaturity::Experimental,
+        };
+
+        // Check if this skill is shadowed
+        let shadow_key = (entry.name.clone(), entry.source_tool);
+        let is_shadowed = if let Some(shadowing_path) = shadow_map.get(&shadow_key) {
+            // This skill is shadowed if it's a user skill and there's a project skill
+            entry.scope == SkillScope::User && shadowing_path != &entry.path
+        } else {
+            false
+        };
+        let shadowed_by = if is_shadowed {
+            shadow_map.get(&shadow_key).cloned()
+        } else {
+            None
+        };
+
+        let id = generate_skill_id(&entry.name, entry.source_tool, entry.scope);
+
+        skills.push(SkillItem {
+            id,
+            name: entry.name,
+            description: entry.description,
+            content: entry.content,
+            source_tool: entry.source_tool,
+            scope: entry.scope,
+            maturity,
+            path: entry.path,
+            is_shadowed,
+            shadowed_by,
+        });
+    }
+
+    // Sort by name, then by scope (project first), then by tool
+    skills.sort_by(|a, b| {
+        a.name.cmp(&b.name)
+            .then_with(|| {
+                // Project skills first
+                match (&a.scope, &b.scope) {
+                    (SkillScope::Project, SkillScope::User) => std::cmp::Ordering::Less,
+                    (SkillScope::User, SkillScope::Project) => std::cmp::Ordering::Greater,
+                    _ => std::cmp::Ordering::Equal,
+                }
+            })
+            .then_with(|| format!("{:?}", a.source_tool).cmp(&format!("{:?}", b.source_tool)))
+    });
+
+    (skills, conflicts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_skill_id() {
+        let id1 = generate_skill_id("test", SkillSourceTool::Claude, SkillScope::User);
+        let id2 = generate_skill_id("test", SkillSourceTool::Claude, SkillScope::User);
+        let id3 = generate_skill_id("test", SkillSourceTool::Codex, SkillScope::User);
+
+        assert_eq!(id1, id2);
+        assert_ne!(id1, id3);
+        assert!(id1.starts_with("skill_"));
+    }
+
+    #[test]
+    fn test_hash_content() {
+        let hash1 = hash_content("hello world");
+        let hash2 = hash_content("hello world");
+        let hash3 = hash_content("different content");
+
+        assert_eq!(hash1, hash2);
+        assert_ne!(hash1, hash3);
+    }
+
+    #[test]
+    fn test_maturity_by_tool() {
+        let entries = vec![
+            RawSkillEntry {
+                name: "test".to_string(),
+                description: "Test".to_string(),
+                content: "content".to_string(),
+                content_hash: 12345,
+                source_tool: SkillSourceTool::Claude,
+                scope: SkillScope::User,
+                path: "/test/path".to_string(),
+            },
+            RawSkillEntry {
+                name: "test2".to_string(),
+                description: "Test2".to_string(),
+                content: "content".to_string(),
+                content_hash: 12345,
+                source_tool: SkillSourceTool::Gemini,
+                scope: SkillScope::User,
+                path: "/test/path2".to_string(),
+            },
+        ];
+
+        let (skills, _) = process_skill_entries(entries);
+
+        let claude_skill = skills.iter().find(|s| s.source_tool == SkillSourceTool::Claude).unwrap();
+        let gemini_skill = skills.iter().find(|s| s.source_tool == SkillSourceTool::Gemini).unwrap();
+
+        assert_eq!(claude_skill.maturity, SkillMaturity::Stable);
+        assert_eq!(gemini_skill.maturity, SkillMaturity::Experimental);
+    }
+
+    #[test]
+    fn test_conflict_detection() {
+        let entries = vec![
+            RawSkillEntry {
+                name: "shared".to_string(),
+                description: "Test".to_string(),
+                content: "content version 1".to_string(),
+                content_hash: hash_content("content version 1"),
+                source_tool: SkillSourceTool::Claude,
+                scope: SkillScope::User,
+                path: "/claude/path".to_string(),
+            },
+            RawSkillEntry {
+                name: "shared".to_string(),
+                description: "Test".to_string(),
+                content: "content version 2".to_string(),
+                content_hash: hash_content("content version 2"),
+                source_tool: SkillSourceTool::Codex,
+                scope: SkillScope::User,
+                path: "/codex/path".to_string(),
+            },
+        ];
+
+        let (_, conflicts) = process_skill_entries(entries);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].name, "shared");
+        assert_eq!(conflicts[0].conflicting_paths.len(), 2);
+    }
+
+    #[test]
+    fn test_shadowing_detection() {
+        let entries = vec![
+            RawSkillEntry {
+                name: "myskill".to_string(),
+                description: "Project version".to_string(),
+                content: "project content".to_string(),
+                content_hash: 111,
+                source_tool: SkillSourceTool::Codex,
+                scope: SkillScope::Project,
+                path: "/project/.codex/skills/myskill/SKILL.md".to_string(),
+            },
+            RawSkillEntry {
+                name: "myskill".to_string(),
+                description: "User version".to_string(),
+                content: "user content".to_string(),
+                content_hash: 222,
+                source_tool: SkillSourceTool::Codex,
+                scope: SkillScope::User,
+                path: "/home/.agents/skills/myskill/SKILL.md".to_string(),
+            },
+        ];
+
+        let (skills, _) = process_skill_entries(entries);
+
+        let project_skill = skills.iter().find(|s| s.scope == SkillScope::Project).unwrap();
+        let user_skill = skills.iter().find(|s| s.scope == SkillScope::User).unwrap();
+
+        assert!(!project_skill.is_shadowed);
+        assert!(user_skill.is_shadowed);
+        assert!(user_skill.shadowed_by.is_some());
+    }
+}

--- a/src/components/mcps/MCPIcon.tsx
+++ b/src/components/mcps/MCPIcon.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Globe, Terminal } from "lucide-react";
+import { Globe } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface MCPIconProps {

--- a/src/components/skills/ConflictWarning.tsx
+++ b/src/components/skills/ConflictWarning.tsx
@@ -1,0 +1,44 @@
+import { AlertTriangle } from "lucide-react";
+import type { SkillConflict } from "@/types";
+import { ToolBadge } from "@/components/mcps/ToolBadge";
+
+interface ConflictWarningProps {
+  conflicts: SkillConflict[];
+}
+
+export function ConflictWarning({ conflicts }: ConflictWarningProps) {
+  if (conflicts.length === 0) return null;
+
+  return (
+    <div className="mb-4 rounded-lg border border-yellow-500/20 bg-yellow-500/5 p-4">
+      <div className="flex items-center gap-2 text-yellow-600">
+        <AlertTriangle className="h-5 w-5 shrink-0" />
+        <span className="font-medium">
+          {conflicts.length} skill conflict{conflicts.length !== 1 ? "s" : ""}{" "}
+          detected
+        </span>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        The following skills have the same name but different content across
+        tools:
+      </p>
+      <ul className="mt-2 space-y-2">
+        {conflicts.map((conflict) => (
+          <li key={conflict.name} className="text-sm">
+            <div className="flex items-center gap-2">
+              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+                {conflict.name}
+              </code>
+              <span className="text-muted-foreground">in</span>
+              <div className="flex gap-1">
+                {conflict.tools.map((tool) => (
+                  <ToolBadge key={tool} tool={tool} />
+                ))}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/skills/MaturityBadge.tsx
+++ b/src/components/skills/MaturityBadge.tsx
@@ -1,0 +1,33 @@
+import type { Maturity } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface MaturityBadgeProps {
+  maturity: Maturity;
+  className?: string;
+}
+
+const maturityStyles: Record<Maturity, string> = {
+  stable: "bg-green-500/10 text-green-600 border-green-500/20",
+  experimental: "bg-yellow-500/10 text-yellow-600 border-yellow-500/20",
+  deprecated: "bg-red-500/10 text-red-600 border-red-500/20",
+};
+
+const maturityLabels: Record<Maturity, string> = {
+  stable: "Stable",
+  experimental: "Experimental",
+  deprecated: "Deprecated",
+};
+
+export function MaturityBadge({ maturity, className }: MaturityBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider",
+        maturityStyles[maturity],
+        className
+      )}
+    >
+      {maturityLabels[maturity]}
+    </span>
+  );
+}

--- a/src/components/skills/SkillCard.tsx
+++ b/src/components/skills/SkillCard.tsx
@@ -1,0 +1,54 @@
+import { Sparkles, EyeOff, ChevronRight } from "lucide-react";
+import type { SkillItem } from "@/types";
+import { cn } from "@/lib/utils";
+import { ToolBadge } from "@/components/mcps/ToolBadge";
+import { MaturityBadge } from "./MaturityBadge";
+
+interface SkillCardProps {
+  skill: SkillItem;
+  onClick: () => void;
+}
+
+export function SkillCard({ skill, onClick }: SkillCardProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-muted/50",
+        skill.isShadowed && "opacity-60"
+      )}
+    >
+      {/* Icon */}
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+        <Sparkles className="h-5 w-5 text-primary" />
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h3 className="truncate font-medium">{skill.name}</h3>
+          <ToolBadge tool={skill.sourceTool} />
+          <MaturityBadge maturity={skill.maturity} />
+          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
+            {skill.scope}
+          </span>
+          {skill.isShadowed && (
+            <span
+              className="flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+              title={`Shadowed by: ${skill.shadowedBy}`}
+            >
+              <EyeOff className="h-3 w-3" />
+              Shadowed
+            </span>
+          )}
+        </div>
+        <p className="mt-0.5 truncate text-sm text-muted-foreground">
+          {skill.description}
+        </p>
+      </div>
+
+      {/* Arrow */}
+      <ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" />
+    </button>
+  );
+}

--- a/src/components/skills/SkillList.tsx
+++ b/src/components/skills/SkillList.tsx
@@ -1,0 +1,67 @@
+import { Sparkles } from "lucide-react";
+import { useState } from "react";
+import type { SkillItem } from "@/types";
+import { SkillCard } from "./SkillCard";
+import { SkillViewer } from "./SkillViewer";
+
+interface SkillListProps {
+  skills: SkillItem[];
+}
+
+export function SkillList({ skills }: SkillListProps) {
+  const [selectedSkill, setSelectedSkill] = useState<SkillItem | null>(null);
+
+  if (skills.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border p-8 text-center">
+        <Sparkles className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+        <h3 className="font-medium">No Skills Found</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          No skills are configured in Claude Code, Codex CLI, or Gemini CLI.
+        </p>
+        <p className="mt-3 text-xs text-muted-foreground">Add skills to:</p>
+        <ul className="mt-1 space-y-0.5 text-xs text-muted-foreground">
+          <li>
+            <code className="rounded bg-muted px-1">
+              ~/.claude/skills/&lt;name&gt;/SKILL.md
+            </code>{" "}
+            for Claude Code
+          </li>
+          <li>
+            <code className="rounded bg-muted px-1">
+              ~/.agents/skills/&lt;name&gt;/SKILL.md
+            </code>{" "}
+            for Codex CLI
+          </li>
+          <li>
+            <code className="rounded bg-muted px-1">
+              ~/.gemini/skills/&lt;name&gt;/SKILL.md
+            </code>{" "}
+            for Gemini CLI
+          </li>
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-3">
+        {skills.map((skill) => (
+          <SkillCard
+            key={skill.id}
+            skill={skill}
+            onClick={() => setSelectedSkill(skill)}
+          />
+        ))}
+      </div>
+
+      {selectedSkill && (
+        <SkillViewer
+          skill={selectedSkill}
+          onClose={() => setSelectedSkill(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/skills/SkillViewer.tsx
+++ b/src/components/skills/SkillViewer.tsx
@@ -1,0 +1,81 @@
+import { X, Copy, Check, FolderOpen } from "lucide-react";
+import { useState } from "react";
+import type { SkillItem } from "@/types";
+import { ToolBadge } from "@/components/mcps/ToolBadge";
+import { MaturityBadge } from "./MaturityBadge";
+import { Button } from "@/components/ui/button";
+
+interface SkillViewerProps {
+  skill: SkillItem;
+  onClose: () => void;
+}
+
+export function SkillViewer({ skill, onClose }: SkillViewerProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(skill.content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="flex max-h-[90vh] w-full max-w-3xl flex-col rounded-lg border border-border bg-background shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-3">
+            <h2 className="text-lg font-semibold">{skill.name}</h2>
+            <ToolBadge tool={skill.sourceTool} />
+            <MaturityBadge maturity={skill.maturity} />
+            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
+              {skill.scope}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 hover:bg-muted"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Description */}
+        <div className="border-b border-border bg-muted/30 px-4 py-2">
+          <p className="text-sm text-muted-foreground">{skill.description}</p>
+        </div>
+
+        {/* Content */}
+        <div className="relative flex-1 overflow-auto">
+          <div className="absolute right-2 top-2 z-10">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleCopy}
+              className="bg-background"
+            >
+              {copied ? (
+                <Check className="mr-1.5 h-3.5 w-3.5" />
+              ) : (
+                <Copy className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              {copied ? "Copied" : "Copy"}
+            </Button>
+          </div>
+          <pre className="h-full overflow-auto whitespace-pre-wrap p-4 font-mono text-sm">
+            {skill.content}
+          </pre>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center gap-2 border-t border-border px-4 py-2 text-xs text-muted-foreground">
+          <FolderOpen className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate font-mono" title={skill.path}>
+            {skill.path}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/skills/index.ts
+++ b/src/components/skills/index.ts
@@ -1,0 +1,5 @@
+export { SkillList } from "./SkillList";
+export { SkillCard } from "./SkillCard";
+export { SkillViewer } from "./SkillViewer";
+export { MaturityBadge } from "./MaturityBadge";
+export { ConflictWarning } from "./ConflictWarning";

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -1,0 +1,11 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { SkillScanResult } from "@/types";
+
+/**
+ * Scan all skills from Claude Code, Codex CLI, and Gemini CLI
+ */
+export async function scanSkills(
+  workspacePath?: string
+): Promise<SkillScanResult> {
+  return invoke<SkillScanResult>("scan_skills", { workspacePath });
+}

--- a/src/pages/MCPs.tsx
+++ b/src/pages/MCPs.tsx
@@ -1,4 +1,4 @@
-import { Server, RefreshCw, AlertCircle, FolderOpen } from "lucide-react";
+import { RefreshCw, AlertCircle, FolderOpen } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { scanMCPs } from "@/lib/api/mcps";

--- a/src/pages/Skills.tsx
+++ b/src/pages/Skills.tsx
@@ -1,41 +1,94 @@
-import { Sparkles } from "lucide-react";
+import { RefreshCw, AlertCircle, FolderOpen } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { scanSkills } from "@/lib/api/skills";
+import { SkillList, ConflictWarning } from "@/components/skills";
+import { Button } from "@/components/ui/button";
 
 export function Skills() {
   const { current } = useWorkspaceStore();
 
-  if (!current) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center text-center">
-        <Sparkles className="mb-4 h-12 w-12 text-muted-foreground" />
-        <h2 className="text-xl font-semibold">Skills</h2>
-        <p className="mt-2 max-w-md text-muted-foreground">
-          Select a workspace to view installed skills across Claude Code, Codex
-          CLI, and Gemini CLI.
-        </p>
-      </div>
-    );
-  }
+  const {
+    data: result,
+    isLoading,
+    error,
+    refetch,
+    isRefetching,
+  } = useQuery({
+    queryKey: ["skills", current?.repo_root ?? current?.path ?? null],
+    queryFn: () => scanSkills(current?.repo_root ?? current?.path),
+  });
 
   return (
     <div className="p-6">
-      <div className="mb-6">
-        <h2 className="text-2xl font-semibold">Skills</h2>
-        <p className="mt-1 text-muted-foreground">
-          View and manage skills across all tools
-        </p>
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">Skills</h2>
+          <p className="mt-1 text-muted-foreground">
+            View skills configured across Claude Code, Codex CLI, and Gemini CLI
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refetch()}
+          disabled={isLoading || isRefetching}
+        >
+          <RefreshCw
+            className={`mr-2 h-4 w-4 ${isRefetching ? "animate-spin" : ""}`}
+          />
+          Refresh
+        </Button>
       </div>
 
-      {/* Placeholder for Skills list - will be implemented in Issue 3 */}
-      <div className="rounded-lg border border-border bg-card p-8 text-center">
-        <Sparkles className="mx-auto mb-4 h-10 w-10 text-muted-foreground" />
-        <p className="text-muted-foreground">
-          Skills scanner will be implemented in Issue 3.
+      {!current && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+          <FolderOpen className="h-4 w-4 shrink-0" />
+          <span>
+            Showing user-level skills. Select a workspace to also see
+            project-level skills.
+          </span>
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <RefreshCw className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-4">
+          <div className="flex items-center gap-2 text-red-600">
+            <AlertCircle className="h-5 w-5" />
+            <span className="font-medium">Failed to scan skills</span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : "Unknown error occurred"}
+          </p>
+        </div>
+      )}
+
+      {result && (
+        <>
+          <ConflictWarning conflicts={result.conflicts} />
+          <SkillList skills={result.skills} />
+        </>
+      )}
+
+      {result && result.skills.length > 0 && (
+        <p className="mt-4 text-center text-xs text-muted-foreground">
+          Found {result.skills.length} skill
+          {result.skills.length !== 1 ? "s" : ""} across your configured tools
+          {result.conflicts.length > 0 && (
+            <span className="text-yellow-600">
+              {" "}
+              ({result.conflicts.length} conflict
+              {result.conflicts.length !== 1 ? "s" : ""} detected)
+            </span>
+          )}
         </p>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Workspace: {current.name}
-        </p>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,14 +103,55 @@ export interface MCPItem {
 }
 
 /**
- * Skill configuration (normalized)
+ * Skill scope (user or project level)
  */
-export interface Skill {
+export type SkillScope = "user" | "project";
+
+/**
+ * Skill item returned from the scanner
+ * Matches the Rust SkillItem struct
+ */
+export interface SkillItem {
+  /** Unique identifier */
+  id: string;
+  /** Skill name from frontmatter */
   name: string;
+  /** Skill description from frontmatter */
   description: string;
+  /** Full markdown content */
   content: string;
+  /** Which tool this skill is from */
   sourceTool: SourceTool;
-  scope: Scope;
-  path: string;
+  /** Scope level (user or project) */
+  scope: SkillScope;
+  /** Feature maturity (stable or experimental) */
   maturity: Maturity;
+  /** Absolute path to the SKILL.md file */
+  path: string;
+  /** True if this skill is shadowed by a higher-precedence skill */
+  isShadowed: boolean;
+  /** Path of the skill that shadows this one */
+  shadowedBy: string | null;
+}
+
+/**
+ * Conflict information when same skill name has different content
+ */
+export interface SkillConflict {
+  /** Skill name that has conflicts */
+  name: string;
+  /** Paths of skills with different content */
+  conflictingPaths: string[];
+  /** Tools that have this conflict */
+  tools: SourceTool[];
+}
+
+/**
+ * Result of scanning all skills
+ */
+export interface SkillScanResult {
+  /** All discovered skills */
+  skills: SkillItem[];
+  /** Detected conflicts (same name, different content) */
+  conflicts: SkillConflict[];
 }


### PR DESCRIPTION
## Summary

Implements Issue 3: Skills Scanner with full discovery and management across Claude Code, Codex CLI, and Gemini CLI. Adds support for both YAML frontmatter and plain markdown skill formats.

## Features

- Multi-tool skill scanning (Claude, Codex, Gemini) at user and project levels
- YAML frontmatter parsing with fallback to directory name and first meaningful line
- Conflict detection for skills with same name but different content
- Shadowing detection showing which skills override others
- Maturity badges (Stable for Claude/Codex, Experimental for Gemini)
- Skill viewer modal with full content display and copy functionality

## Testing

Skills are auto-discovered from standard paths:
- Claude: ~/.claude/skills/<name>/SKILL.md
- Codex: ~/.agents/skills/<name>/SKILL.md  
- Gemini: ~/.gemini/skills/<name>/SKILL.md

All 20 Rust tests pass, TypeScript builds successfully.