### PR TITLE
Fix MCP sync compatibility and validation

### DIFF
--- a/issues/02-done-mcp-registry.md
+++ b/issues/02-done-mcp-registry.md
@@ -19,7 +19,7 @@ Scan and display all MCP servers configured across Claude Code, Codex CLI, and G
 > **Project root**: Use repo root (`.git` parent) when found, otherwise use selected folder.
 - [x] Tauri command `scan_mcps()` returns unified list
 - [x] MCP list displays: name, source tool badge, command, args, scope (user/project)
-- [x] Health indicator: ✓ healthy / ? unknown (default) / ✗ failed
+- [x] Health indicator shown (default: ? unknown)
 - [x] Click MCP to see full config details
 - [x] "In Claude, Codex, Gemini" badges showing where each MCP is configured
 - [x] Empty state when no MCPs configured
@@ -59,18 +59,12 @@ args = ["-y", "@github/mcp-server"]
 GITHUB_TOKEN = "..."
 ```
 
-### Health Check (Opt-In)
+### Health Status Scope
 
-**Default state: "unknown"** — guessing ports from command/args produces false negatives.
+This issue only covers MCP status display with default `unknown`.
 
-Health check is opt-in via manual "Test" button per MCP:
-1. User clicks "Test" on an MCP
-2. Show warning: "This will run: `npx -y @org/mcp-server`"
-3. If confirmed, spawn command with 5s timeout
-4. Check if MCP responds to protocol handshake
-5. Show: ✓ healthy / ✗ failed / ? unknown (default)
-
-**No auto-testing** — executing commands from config is a security risk without explicit consent.
+Active health testing (manual "Test" button, confirmation dialog, protocol handshake, timeouts)
+is tracked separately in **Issue 6: MCP Health Testing**.
 
 ### LoadoutItem Shape
 
@@ -120,9 +114,8 @@ src/
 4. Launch Loadout → MCPs tab
 5. See unified list with all MCPs
 6. Each shows correct source badges
-7. Health shows "?" (unknown) by default — no auto-testing
-8. Click "Test" on an MCP → confirmation dialog shows command
-9. Confirm → MCP tested → status updates to ✓ or ✗
+7. Health shows "?" (unknown) by default
+8. No command execution occurs in MCP registry scan flow
 10. API keys/secrets are masked (show `***`)
 11. Click MCP → see full details
 

--- a/issues/05-done-sync-mcp-skill.md
+++ b/issues/05-done-sync-mcp-skill.md
@@ -15,29 +15,27 @@ Add the ability to add an MCP or install a skill to all three tools at once. Thi
 
 > ⚠️ **Implementation order**: Build and test safe write infra BEFORE any actual write features. This is the foundation.
 
-- [ ] Atomic writes (write to temp, then rename)
-- [ ] Automatic backup before every write (`~/.loadout/backups/`)
-- [ ] Format-preserving TOML edits (preserve comments) using `toml_edit`
-- [ ] Validation before write (parse result, verify structure)
+- [x] Atomic writes (write to temp, then rename)
+- [x] Automatic backup before every write (`~/.loadout/backups/`)
+- [x] Format-preserving TOML edits (preserve comments) using `toml_edit`
+- [x] Validation before write (parse result, verify structure)
 - [ ] Unit tests for atomic write + backup + rollback
 
 ### Add MCP to All Tools
-- [ ] Form: name, command, args, env vars
-- [ ] Select target tools (checkboxes)
-- [ ] Preview generated config (JSON for Claude/Gemini, TOML for Codex)
-- [ ] Write to all selected tools
-- [ ] Success confirmation with files modified
+- [x] Form: name, command, args, env vars
+- [x] Select target tools (checkboxes)
+- [x] Preview generated config (JSON for Claude/Gemini, TOML for Codex)
+- [x] Write to all selected tools
+- [x] Success confirmation with files modified
 
 ### Install Skill to All Tools
-- [ ] Input: GitHub URL or paste SKILL.md content
-- [ ] Parse and validate SKILL.md frontmatter
-- [ ] Preview skill content
-- [ ] Select target tools (checkboxes)
-- [ ] Write to correct path per tool:
+- [x] Input: skill name + content (build SKILL.md)
+- [x] Select target tools (checkboxes)
+- [x] Write to correct path per tool:
   - Claude: `~/.claude/skills/<name>/SKILL.md`
   - Codex: `$HOME/.agents/skills/<name>/SKILL.md`
   - Gemini: `~/.gemini/skills/<name>/SKILL.md`
-- [ ] Success confirmation with paths created
+- [x] Success confirmation with paths created
 
 ## Technical Details
 
@@ -102,9 +100,10 @@ impl MCPServer {
 ### Rust Crates
 
 - `toml_edit` — format-preserving TOML (not `toml`)
-- `reqwest` — fetch skills from GitHub URLs
 - `tempfile` — atomic writes
 - `chrono` — timestamps for backups
+
+> URL/file import is tracked in **Issue 7: Import Skills & MCPs from File or URL**.
 
 ### Files to Create
 
@@ -145,14 +144,17 @@ src/
 
 ### Install Skill
 1. Click "Install Skill" button
-2. Paste GitHub URL: `https://github.com/org/cool-skill`
-3. Preview shows skill name, description, content
-4. Select Claude + Codex (not Gemini — experimental warning shown)
-5. Click "Install"
-6. Verify folders created:
+2. Enter skill name + instructions/content
+3. Select Claude + Codex (not Gemini — experimental warning shown)
+4. Click "Install"
+5. Verify folders created:
    - `~/.claude/skills/cool-skill/SKILL.md`
    - `~/.agents/skills/cool-skill/SKILL.md`
-7. Skill appears in Skills list
+6. Skill appears in Skills list
+
+### Import from URL/File
+
+Tracked in **Issue 7**.
 
 ## Dependencies
 

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -37,6 +37,7 @@ pub struct InstallSkillRequest {
 pub struct SyncMCPRequest {
     pub name: String,
     pub source_tool: String,
+    pub source_path: Option<String>,
     pub target_tools: Vec<String>,
 }
 
@@ -88,13 +89,32 @@ fn mcp_config_path(tool: &str) -> Result<PathBuf, String> {
     }
 }
 
+fn is_supported_mcp_type(mcp_type: &str) -> bool {
+    matches!(mcp_type, "stdio" | "http")
+}
+
+fn ensure_tool_compatible_with_mcp(tool: &str, mcp_type: &str) -> Result<(), String> {
+    if tool == "codex" && mcp_type == "http" {
+        return Err("Codex CLI only supports stdio MCP servers".to_string());
+    }
+    Ok(())
+}
+
 /// Preview the generated config for each selected tool without writing
 #[tauri::command]
 pub fn preview_mcp_configs(request: AddMCPRequest) -> Result<PreviewResult, String> {
-    let mcp = request.to_server_input();
+    let normalized_mcp_type = request.mcp_type.trim().to_ascii_lowercase();
+    if !is_supported_mcp_type(&normalized_mcp_type) {
+        return Err("MCP type must be either 'stdio' or 'http'".to_string());
+    }
+
+    let mut mcp = request.to_server_input();
+    mcp.mcp_type = normalized_mcp_type;
     let mut configs = Vec::new();
 
     for tool in &request.target_tools {
+        ensure_tool_compatible_with_mcp(tool, &mcp.mcp_type)?;
+
         match tool.as_str() {
             "claude" => configs.push(PreviewConfig {
                 tool: "claude".to_string(),
@@ -121,17 +141,29 @@ pub fn preview_mcp_configs(request: AddMCPRequest) -> Result<PreviewResult, Stri
 /// Add an MCP to all selected tools
 #[tauri::command]
 pub fn add_mcp_to_tools(request: AddMCPRequest) -> Result<WriteResult, String> {
+    let normalized_mcp_type = request.mcp_type.trim().to_ascii_lowercase();
+
     // Validate input
     if request.name.trim().is_empty() {
         return Err("MCP name is required".to_string());
     }
 
-    if request.mcp_type == "stdio" && request.command.as_ref().map_or(true, |c| c.trim().is_empty())
+    if !is_supported_mcp_type(&normalized_mcp_type) {
+        return Err("MCP type must be either 'stdio' or 'http'".to_string());
+    }
+
+    if normalized_mcp_type == "stdio"
+        && request
+            .command
+            .as_ref()
+            .map_or(true, |c| c.trim().is_empty())
     {
         return Err("Command is required for stdio MCPs".to_string());
     }
 
-    if request.mcp_type == "http" && request.url.as_ref().map_or(true, |u| u.trim().is_empty()) {
+    if normalized_mcp_type == "http"
+        && request.url.as_ref().map_or(true, |u| u.trim().is_empty())
+    {
         return Err("URL is required for http MCPs".to_string());
     }
 
@@ -139,11 +171,17 @@ pub fn add_mcp_to_tools(request: AddMCPRequest) -> Result<WriteResult, String> {
         return Err("At least one target tool must be selected".to_string());
     }
 
-    let mcp = request.to_server_input();
+    let mut mcp = request.to_server_input();
+    mcp.mcp_type = normalized_mcp_type;
     let mut modified_files = Vec::new();
     let mut errors = Vec::new();
 
     for tool in &request.target_tools {
+        if let Err(e) = ensure_tool_compatible_with_mcp(tool, &mcp.mcp_type) {
+            errors.push(format!("{}: {}", tool, e));
+            continue;
+        }
+
         let path = match mcp_config_path(tool) {
             Ok(p) => p,
             Err(e) => {
@@ -173,54 +211,88 @@ pub fn add_mcp_to_tools(request: AddMCPRequest) -> Result<WriteResult, String> {
 }
 
 /// Read the real (unmasked) MCP config from a source tool
-fn read_mcp_from_source(name: &str, source_tool: &str) -> Result<MCPServerInput, String> {
+fn read_mcp_from_source(
+    name: &str,
+    source_tool: &str,
+    source_path: Option<&str>,
+) -> Result<MCPServerInput, String> {
     let home = dirs::home_dir().ok_or("Could not determine home directory")?;
 
     match source_tool {
         "claude" => {
-            let path = home.join(".claude.json");
-            let config = parse_claude_config(&path)?;
-            let server = config
-                .mcp_servers
-                .get(name)
-                .ok_or(format!("MCP '{}' not found in Claude config", name))?;
-            Ok(MCPServerInput {
-                mcp_type: server.mcp_type.clone(),
-                command: server.command.clone(),
-                args: server.args.clone(),
-                url: server.url.clone(),
-                env: server.env.clone(),
-            })
+            let default_path = home.join(".claude.json");
+            let mut candidate_paths = Vec::new();
+            if let Some(path) = source_path {
+                candidate_paths.push(PathBuf::from(path));
+            }
+            if !candidate_paths.iter().any(|path| path == &default_path) {
+                candidate_paths.push(default_path);
+            }
+
+            for path in candidate_paths {
+                let config = parse_claude_config(&path)?;
+                if let Some(server) = config.mcp_servers.get(name) {
+                    return Ok(MCPServerInput {
+                        mcp_type: server.mcp_type.clone(),
+                        command: server.command.clone(),
+                        args: server.args.clone(),
+                        url: server.url.clone(),
+                        env: server.env.clone(),
+                    });
+                }
+            }
+
+            Err(format!("MCP '{}' not found in Claude configs", name))
         }
         "codex" => {
-            let path = home.join(".codex").join("config.toml");
-            let config = parse_codex_config(&path)?;
-            let server = config
-                .mcp_servers
-                .get(name)
-                .ok_or(format!("MCP '{}' not found in Codex config", name))?;
-            Ok(MCPServerInput {
-                mcp_type: "stdio".to_string(),
-                command: Some(server.command.clone()),
-                args: server.args.clone(),
-                url: None,
-                env: server.env.clone(),
-            })
+            let default_path = home.join(".codex").join("config.toml");
+            let mut candidate_paths = Vec::new();
+            if let Some(path) = source_path {
+                candidate_paths.push(PathBuf::from(path));
+            }
+            if !candidate_paths.iter().any(|path| path == &default_path) {
+                candidate_paths.push(default_path);
+            }
+
+            for path in candidate_paths {
+                let config = parse_codex_config(&path)?;
+                if let Some(server) = config.mcp_servers.get(name) {
+                    return Ok(MCPServerInput {
+                        mcp_type: "stdio".to_string(),
+                        command: Some(server.command.clone()),
+                        args: server.args.clone(),
+                        url: None,
+                        env: server.env.clone(),
+                    });
+                }
+            }
+
+            Err(format!("MCP '{}' not found in Codex configs", name))
         }
         "gemini" => {
-            let path = home.join(".gemini").join("settings.json");
-            let config = parse_gemini_config(&path)?;
-            let server = config
-                .mcp_servers
-                .get(name)
-                .ok_or(format!("MCP '{}' not found in Gemini config", name))?;
-            Ok(MCPServerInput {
-                mcp_type: server.mcp_type.clone(),
-                command: server.command.clone(),
-                args: server.args.clone(),
-                url: server.url.clone(),
-                env: server.env.clone(),
-            })
+            let default_path = home.join(".gemini").join("settings.json");
+            let mut candidate_paths = Vec::new();
+            if let Some(path) = source_path {
+                candidate_paths.push(PathBuf::from(path));
+            }
+            if !candidate_paths.iter().any(|path| path == &default_path) {
+                candidate_paths.push(default_path);
+            }
+
+            for path in candidate_paths {
+                let config = parse_gemini_config(&path)?;
+                if let Some(server) = config.mcp_servers.get(name) {
+                    return Ok(MCPServerInput {
+                        mcp_type: server.mcp_type.clone(),
+                        command: server.command.clone(),
+                        args: server.args.clone(),
+                        url: server.url.clone(),
+                        env: server.env.clone(),
+                    });
+                }
+            }
+
+            Err(format!("MCP '{}' not found in Gemini configs", name))
         }
         _ => Err(format!("Unknown source tool: {}", source_tool)),
     }
@@ -238,12 +310,21 @@ pub fn sync_mcp_to_tools(request: SyncMCPRequest) -> Result<WriteResult, String>
     }
 
     // Read the real config from the source tool (unmasked env values)
-    let mcp = read_mcp_from_source(&request.name, &request.source_tool)?;
+    let mcp = read_mcp_from_source(
+        &request.name,
+        &request.source_tool,
+        request.source_path.as_deref(),
+    )?;
 
     let mut modified_files = Vec::new();
     let mut errors = Vec::new();
 
     for tool in &request.target_tools {
+        if let Err(e) = ensure_tool_compatible_with_mcp(tool, &mcp.mcp_type) {
+            errors.push(format!("{}: {}", tool, e));
+            continue;
+        }
+
         let path = match mcp_config_path(tool) {
             Ok(p) => p,
             Err(e) => {
@@ -288,11 +369,12 @@ pub fn install_skill_to_tools(request: InstallSkillRequest) -> Result<WriteResul
         return Err("At least one target tool must be selected".to_string());
     }
 
+    let validated_name = skill_writer::validate_skill_name(&request.name)?;
     let mut modified_files = Vec::new();
     let mut errors = Vec::new();
 
     for tool in &request.target_tools {
-        match skill_writer::write_skill(&request.name, &request.content, tool) {
+        match skill_writer::write_skill(&validated_name, &request.content, tool) {
             Ok(path) => modified_files.push(path),
             Err(e) => errors.push(format!("{}: {}", tool, e)),
         }
@@ -303,4 +385,71 @@ pub fn install_skill_to_tools(request: InstallSkillRequest) -> Result<WriteResul
         modified_files,
         errors,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_codex_rejects_http_mcp() {
+        assert!(ensure_tool_compatible_with_mcp("codex", "http").is_err());
+    }
+
+    #[test]
+    fn test_codex_accepts_stdio_mcp() {
+        assert!(ensure_tool_compatible_with_mcp("codex", "stdio").is_ok());
+    }
+
+    #[test]
+    fn test_claude_accepts_http_mcp() {
+        assert!(ensure_tool_compatible_with_mcp("claude", "http").is_ok());
+    }
+
+    #[test]
+    fn test_read_mcp_from_claude_source_path() {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(
+            file.path(),
+            r#"{
+  "mcpServers": {
+    "project-server": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["server.js"]
+    }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let mcp = read_mcp_from_source(
+            "project-server",
+            "claude",
+            Some(file.path().to_string_lossy().as_ref()),
+        )
+        .unwrap();
+
+        assert_eq!(mcp.mcp_type, "stdio");
+        assert_eq!(mcp.command.as_deref(), Some("node"));
+        assert_eq!(mcp.args, vec!["server.js"]);
+    }
+
+    #[test]
+    fn test_preview_rejects_http_for_codex() {
+        let request = AddMCPRequest {
+            name: "http-server".to_string(),
+            mcp_type: "http".to_string(),
+            command: None,
+            args: vec![],
+            url: Some("https://example.com/mcp".to_string()),
+            env: HashMap::new(),
+            target_tools: vec!["codex".to_string()],
+        };
+
+        let err = preview_mcp_configs(request).unwrap_err();
+        assert!(err.contains("Codex CLI only supports stdio"));
+    }
 }

--- a/src-tauri/src/writers/mcp_writer.rs
+++ b/src-tauri/src/writers/mcp_writer.rs
@@ -44,6 +44,17 @@ pub fn write_mcp_to_claude(name: &str, mcp: &MCPServerInput, path: &Path) -> Res
 /// Uses toml_edit to preserve comments and formatting.
 /// Creates the file with a minimal structure if it doesn't exist.
 pub fn write_mcp_to_codex(name: &str, mcp: &MCPServerInput, path: &Path) -> Result<(), String> {
+    if mcp.mcp_type == "http" {
+        return Err("Codex CLI does not support HTTP MCP servers".to_string());
+    }
+
+    let command = mcp
+        .command
+        .as_deref()
+        .map(str::trim)
+        .filter(|cmd| !cmd.is_empty())
+        .ok_or_else(|| "Codex MCP entries require a command".to_string())?;
+
     let mut doc: DocumentMut = if path.exists() {
         let content = fs::read_to_string(path)
             .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
@@ -61,10 +72,7 @@ pub fn write_mcp_to_codex(name: &str, mcp: &MCPServerInput, path: &Path) -> Resu
 
     // Create the server entry as a table
     let mut server_table = toml_edit::Table::new();
-
-    if let Some(cmd) = &mcp.command {
-        server_table["command"] = toml_edit::value(cmd.as_str());
-    }
+    server_table["command"] = toml_edit::value(command);
 
     if !mcp.args.is_empty() {
         let mut args_array = toml_edit::Array::new();
@@ -238,6 +246,15 @@ mod tests {
         let linear = servers.get("linear").unwrap();
         assert_eq!(linear.get("type").unwrap(), "http");
         assert_eq!(linear.get("url").unwrap(), "https://mcp.linear.app/mcp");
+    }
+
+    #[test]
+    fn test_write_http_mcp_to_codex_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let err = write_mcp_to_codex("linear", &http_mcp(), &path).unwrap_err();
+        assert!(err.contains("does not support HTTP"));
     }
 
     #[test]

--- a/src-tauri/src/writers/skill_writer.rs
+++ b/src-tauri/src/writers/skill_writer.rs
@@ -3,6 +3,37 @@
 use crate::writers::atomic::atomic_write;
 use std::path::PathBuf;
 
+/// Validate a skill name before using it as a directory name.
+///
+/// Only ASCII alphanumeric characters plus `.`, `_`, and `-` are allowed.
+/// Path separators and traversal sequences are rejected.
+pub fn validate_skill_name(name: &str) -> Result<String, String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err("Skill name is required".to_string());
+    }
+
+    if trimmed == "." || trimmed == ".." {
+        return Err("Skill name cannot be '.' or '..'".to_string());
+    }
+
+    if trimmed.contains('/') || trimmed.contains('\\') || trimmed.contains('\0') {
+        return Err("Skill name cannot contain path separators".to_string());
+    }
+
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        return Err(
+            "Skill name can only contain letters, numbers, hyphens, underscores, and dots"
+                .to_string(),
+        );
+    }
+
+    Ok(trimmed.to_string())
+}
+
 /// Tool-specific user-level skill directories
 fn skill_dir_for_tool(tool: &str) -> Result<PathBuf, String> {
     let home = dirs::home_dir().ok_or("Could not determine home directory")?;
@@ -18,8 +49,9 @@ fn skill_dir_for_tool(tool: &str) -> Result<PathBuf, String> {
 ///
 /// Creates `{skills_dir}/{name}/SKILL.md` and returns the full path.
 pub fn write_skill(name: &str, content: &str, tool: &str) -> Result<String, String> {
+    let safe_name = validate_skill_name(name)?;
     let skills_dir = skill_dir_for_tool(tool)?;
-    let skill_dir = skills_dir.join(name);
+    let skill_dir = skills_dir.join(&safe_name);
     let skill_path = skill_dir.join("SKILL.md");
 
     atomic_write(&skill_path, content)?;
@@ -48,6 +80,21 @@ mod tests {
     #[test]
     fn test_skill_dir_for_unknown_tool() {
         assert!(skill_dir_for_tool("unknown").is_err());
+    }
+
+    #[test]
+    fn test_validate_skill_name_accepts_safe_names() {
+        assert_eq!(validate_skill_name("my-skill").unwrap(), "my-skill");
+        assert_eq!(validate_skill_name("skill_v2").unwrap(), "skill_v2");
+        assert_eq!(validate_skill_name("build.tool").unwrap(), "build.tool");
+    }
+
+    #[test]
+    fn test_validate_skill_name_rejects_path_traversal() {
+        assert!(validate_skill_name("../evil").is_err());
+        assert!(validate_skill_name("..").is_err());
+        assert!(validate_skill_name("foo/bar").is_err());
+        assert!(validate_skill_name(r"foo\bar").is_err());
     }
 
     #[test]

--- a/src/components/mcps/MCPCard.tsx
+++ b/src/components/mcps/MCPCard.tsx
@@ -19,11 +19,15 @@ export function MCPCard({ mcp }: MCPCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [showSync, setShowSync] = useState(false);
 
-  const missingTools = ALL_TOOLS.filter((t) => !mcp.configuredIn.includes(t));
-
   const envKeys = Object.keys(mcp.env);
   const hasEnv = envKeys.length > 0;
   const isHttp = mcp.mcpType === "http";
+  const syncEligibleTools = isHttp
+    ? ALL_TOOLS.filter((tool) => tool !== "codex")
+    : ALL_TOOLS;
+  const missingTools = syncEligibleTools.filter(
+    (tool) => !mcp.configuredIn.includes(tool)
+  );
 
   // Display string for the card preview
   const displayString = isHttp
@@ -162,10 +166,12 @@ export function MCPCard({ mcp }: MCPCardProps) {
           type="mcp"
           name={mcp.name}
           existingTools={mcp.configuredIn}
+          availableTools={syncEligibleTools}
           onSync={(targetTools) =>
             syncMCPToTools({
               name: mcp.name,
               sourceTool: mcp.configuredIn[0],
+              sourcePath: mcp.path,
               targetTools,
             })
           }

--- a/src/components/sync/AddMCPDialog.tsx
+++ b/src/components/sync/AddMCPDialog.tsx
@@ -31,19 +31,24 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
 
   // Preview state
   const [previews, setPreviews] = useState<PreviewConfig[]>([]);
+  const isHttpMCP = mcpType === "http";
+  const disabledTools: SourceTool[] = isHttpMCP ? ["codex"] : [];
+  const effectiveTargetTools = isHttpMCP
+    ? targetTools.filter((tool) => tool !== "codex")
+    : targetTools;
 
   const buildRequest = (): AddMCPRequest => ({
     name: name.trim(),
     mcpType,
-    command: mcpType === "stdio" ? command.trim() || null : null,
-    args: mcpType === "stdio" ? args : [],
-    url: mcpType === "http" ? url.trim() || null : null,
+    command: !isHttpMCP ? command.trim() || null : null,
+    args: !isHttpMCP ? args : [],
+    url: isHttpMCP ? url.trim() || null : null,
     env: Object.fromEntries(
       envVars
         .filter((v) => v.key.trim())
         .map((v) => [v.key.trim(), v.value])
     ),
-    targetTools,
+    targetTools: effectiveTargetTools,
   });
 
   // Preview mutation
@@ -99,8 +104,8 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
 
   const isValid =
     name.trim() &&
-    targetTools.length > 0 &&
-    (mcpType === "stdio" ? command.trim() : url.trim());
+    effectiveTargetTools.length > 0 &&
+    (!isHttpMCP ? command.trim() : url.trim());
 
   // Show success state
   if (writeMutation.isSuccess && writeMutation.data) {
@@ -183,7 +188,7 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
           </div>
 
           {/* stdio fields */}
-          {mcpType === "stdio" && (
+          {!isHttpMCP && (
             <>
               <div className="space-y-2">
                 <label className="text-sm font-medium">Command</label>
@@ -239,7 +244,7 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
           )}
 
           {/* http fields */}
-          {mcpType === "http" && (
+          {isHttpMCP && (
             <div className="space-y-2">
               <label className="text-sm font-medium">URL</label>
               <input
@@ -249,11 +254,15 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
                 placeholder="e.g., https://mcp.linear.app/mcp"
                 className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
               />
+              <p className="text-xs text-muted-foreground">
+                Codex CLI supports only stdio MCP servers, so it is disabled
+                for HTTP MCPs.
+              </p>
             </div>
           )}
 
           {/* Environment Variables */}
-          {mcpType === "stdio" && (
+          {!isHttpMCP && (
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <label className="text-sm font-medium">
@@ -294,9 +303,15 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
 
           {/* Tool Selector */}
           <ToolSelector
-            selectedTools={targetTools}
-            onToolsChange={setTargetTools}
+            selectedTools={effectiveTargetTools}
+            onToolsChange={(tools) =>
+              setTargetTools(
+                isHttpMCP ? tools.filter((tool) => tool !== "codex") : tools
+              )
+            }
             type="mcp"
+            disabledTools={disabledTools}
+            disabledReason="Codex CLI only supports stdio MCP servers"
           />
 
           {/* Preview */}

--- a/src/components/sync/SyncDialog.tsx
+++ b/src/components/sync/SyncDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { X, Loader2, Share2 } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { SourceTool } from "@/types";
@@ -11,6 +11,8 @@ interface SyncDialogProps {
   name: string;
   /** Tools that already have this item */
   existingTools: SourceTool[];
+  /** Restrict sync targets for compatibility (defaults to all tools) */
+  availableTools?: SourceTool[];
   /** Called with selected target tools to perform the sync */
   onSync: (targetTools: SourceTool[]) => Promise<{
     success: boolean;
@@ -28,16 +30,25 @@ export function SyncDialog({
   type,
   name,
   existingTools,
+  availableTools,
   onSync,
   onClose,
   queryKey,
 }: SyncDialogProps) {
   const queryClient = useQueryClient();
-  const missingTools = ALL_TOOLS.filter((t) => !existingTools.includes(t));
+  const allowedTools = useMemo(
+    () => availableTools ?? ALL_TOOLS,
+    [availableTools]
+  );
+  const disabledTools = ALL_TOOLS.filter((t) => !allowedTools.includes(t));
+  const missingTools = allowedTools.filter((t) => !existingTools.includes(t));
   const [targetTools, setTargetTools] = useState<SourceTool[]>(missingTools);
+  const effectiveTargetTools = targetTools.filter((tool) =>
+    allowedTools.includes(tool)
+  );
 
   const syncMutation = useMutation({
-    mutationFn: () => onSync(targetTools),
+    mutationFn: () => onSync(effectiveTargetTools),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [queryKey] });
     },
@@ -93,9 +104,15 @@ export function SyncDialog({
           </p>
 
           <ToolSelector
-            selectedTools={targetTools}
+            selectedTools={effectiveTargetTools}
             onToolsChange={setTargetTools}
             type={type}
+            disabledTools={disabledTools}
+            disabledReason={
+              type === "mcp"
+                ? "This tool does not support this MCP type"
+                : undefined
+            }
           />
 
           {missingTools.length === 0 && (
@@ -114,7 +131,7 @@ export function SyncDialog({
           <Button
             onClick={() => syncMutation.mutate()}
             disabled={
-              targetTools.length === 0 ||
+              effectiveTargetTools.length === 0 ||
               syncMutation.isPending ||
               missingTools.length === 0
             }
@@ -122,8 +139,8 @@ export function SyncDialog({
             {syncMutation.isPending && (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             )}
-            Sync to {targetTools.length} Tool
-            {targetTools.length !== 1 ? "s" : ""}
+            Sync to {effectiveTargetTools.length} Tool
+            {effectiveTargetTools.length !== 1 ? "s" : ""}
           </Button>
         </div>
       </div>

--- a/src/components/sync/ToolSelector.tsx
+++ b/src/components/sync/ToolSelector.tsx
@@ -6,6 +6,8 @@ interface ToolSelectorProps {
   selectedTools: SourceTool[];
   onToolsChange: (tools: SourceTool[]) => void;
   type?: "mcp" | "skill";
+  disabledTools?: SourceTool[];
+  disabledReason?: string;
 }
 
 const tools: { id: SourceTool; label: string; color: string }[] = [
@@ -30,8 +32,14 @@ export function ToolSelector({
   selectedTools,
   onToolsChange,
   type = "mcp",
+  disabledTools = [],
+  disabledReason,
 }: ToolSelectorProps) {
   const toggle = (tool: SourceTool) => {
+    if (disabledTools.includes(tool)) {
+      return;
+    }
+
     if (selectedTools.includes(tool)) {
       onToolsChange(selectedTools.filter((t) => t !== tool));
     } else {
@@ -43,25 +51,33 @@ export function ToolSelector({
     <div className="space-y-2">
       <label className="text-sm font-medium">Target Tools</label>
       <div className="flex flex-wrap gap-3">
-        {tools.map(({ id, label, color }) => (
-          <label
-            key={id}
-            className={cn(
-              "flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
-              selectedTools.includes(id)
-                ? "border-primary bg-primary/5"
-                : "border-border hover:bg-muted/50"
-            )}
-          >
-            <input
-              type="checkbox"
-              checked={selectedTools.includes(id)}
-              onChange={() => toggle(id)}
-              className={cn("h-4 w-4 rounded", color)}
-            />
-            {label}
-          </label>
-        ))}
+        {tools.map(({ id, label, color }) => {
+          const isDisabled = disabledTools.includes(id);
+          return (
+            <label
+              key={id}
+              title={isDisabled ? disabledReason : undefined}
+              className={cn(
+                "flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
+                isDisabled
+                  ? "cursor-not-allowed opacity-50"
+                  : "cursor-pointer",
+                selectedTools.includes(id)
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:bg-muted/50"
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={selectedTools.includes(id)}
+                onChange={() => toggle(id)}
+                disabled={isDisabled}
+                className={cn("h-4 w-4 rounded", color)}
+              />
+              {label}
+            </label>
+          );
+        })}
       </div>
       {type === "skill" && selectedTools.includes("gemini") && (
         <div className="flex items-center gap-2 rounded-md bg-yellow-500/10 px-3 py-2 text-xs text-yellow-700">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -254,6 +254,7 @@ export interface AddMCPRequest {
 export interface SyncMCPRequest {
   name: string;
   sourceTool: SourceTool;
+  sourcePath?: string | null;
   targetTools: SourceTool[];
 }
 


### PR DESCRIPTION
This PR aligns MCP sync behavior across UI, backend, and writers for Claude Code, Gemini CLI, and Codex. It blocks Codex for HTTP MCPs, keeps stdio flows intact, and adds backend guardrails so forced invalid combinations are rejected. It also ensures sync reads from project-level source paths and hardens skill-name validation to prevent path traversal. Done-issue docs were updated to remove scope now tracked in pending issues. Validation included lint/build plus Rust check/test and targeted new unit tests for the new constraints.