### PR TITLE
Add filtering by tool and scope to MCPs and Skills

### DIFF
--- a/src/components/config/RuleViewer.tsx
+++ b/src/components/config/RuleViewer.tsx
@@ -40,7 +40,7 @@ export function RuleViewer({ rule, onClose }: RuleViewerProps) {
         </div>
 
         {/* Content */}
-        <div className="relative flex-1 overflow-auto">
+        <div className="relative min-h-[4rem] flex-1 overflow-auto">
           <div className="absolute right-2 top-2 z-10">
             <Button
               variant="outline"

--- a/src/components/filters/FilterBar.tsx
+++ b/src/components/filters/FilterBar.tsx
@@ -1,0 +1,109 @@
+import { cn } from "@/lib/utils";
+import type { SourceTool } from "@/types";
+
+interface FilterBarProps {
+  activeTools: SourceTool[];
+  onToolsChange: (tools: SourceTool[]) => void;
+  activeScopes: string[];
+  onScopesChange: (scopes: string[]) => void;
+  showScopeFilter: boolean;
+  scopeOptions?: { value: string; label: string }[];
+}
+
+const toolConfig: { id: SourceTool; label: string; activeClass: string }[] = [
+  {
+    id: "claude",
+    label: "Claude",
+    activeClass: "bg-orange-500/15 text-orange-600 border-orange-500/30",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    activeClass: "bg-green-500/15 text-green-600 border-green-500/30",
+  },
+  {
+    id: "gemini",
+    label: "Gemini",
+    activeClass: "bg-blue-500/15 text-blue-600 border-blue-500/30",
+  },
+];
+
+function toggleValue<T>(arr: T[], value: T): T[] {
+  return arr.includes(value)
+    ? arr.filter((v) => v !== value)
+    : [...arr, value];
+}
+
+export function FilterBar({
+  activeTools,
+  onToolsChange,
+  activeScopes,
+  onScopesChange,
+  showScopeFilter,
+  scopeOptions = [
+    { value: "user", label: "User" },
+    { value: "project", label: "Project" },
+  ],
+}: FilterBarProps) {
+  return (
+    <div className="mb-4 flex items-center gap-6">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Tool
+        </span>
+        <div className="flex gap-1">
+          {toolConfig.map(({ id, label, activeClass }) => {
+            const isActive = activeTools.includes(id);
+            return (
+              <button
+                key={id}
+                role="checkbox"
+                aria-checked={isActive}
+                onClick={() => onToolsChange(toggleValue(activeTools, id))}
+                className={cn(
+                  "rounded-md border px-2 py-0.5 text-xs font-medium transition-colors",
+                  isActive
+                    ? activeClass
+                    : "border-border text-muted-foreground hover:bg-muted/50"
+                )}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {showScopeFilter && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Scope
+          </span>
+          <div className="flex gap-1">
+            {scopeOptions.map(({ value, label }) => {
+              const isActive = activeScopes.includes(value);
+              return (
+                <button
+                  key={value}
+                  role="checkbox"
+                  aria-checked={isActive}
+                  onClick={() =>
+                    onScopesChange(toggleValue(activeScopes, value))
+                  }
+                  className={cn(
+                    "rounded-md border px-2 py-0.5 text-xs font-medium transition-colors",
+                    isActive
+                      ? "border-foreground/20 bg-foreground/10 text-foreground"
+                      : "border-border text-muted-foreground hover:bg-muted/50"
+                  )}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/filters/index.ts
+++ b/src/components/filters/index.ts
@@ -1,0 +1,1 @@
+export { FilterBar } from "./FilterBar";

--- a/src/components/mcps/MCPList.tsx
+++ b/src/components/mcps/MCPList.tsx
@@ -1,13 +1,35 @@
-import { Server } from "lucide-react";
+import { Filter, Server } from "lucide-react";
 import type { MCPItem } from "@/types";
 import { MCPCard } from "./MCPCard";
 
 interface MCPListProps {
   mcps: MCPItem[];
+  hasActiveFilters?: boolean;
+  onClearFilters?: () => void;
 }
 
-export function MCPList({ mcps }: MCPListProps) {
+export function MCPList({ mcps, hasActiveFilters, onClearFilters }: MCPListProps) {
   if (mcps.length === 0) {
+    if (hasActiveFilters) {
+      return (
+        <div className="rounded-lg border border-dashed border-border p-8 text-center">
+          <Filter className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+          <h3 className="font-medium">No Matching MCPs</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            No MCP servers match the current filters.
+          </p>
+          {onClearFilters && (
+            <button
+              onClick={onClearFilters}
+              className="mt-3 text-sm text-primary hover:underline"
+            >
+              Clear all filters
+            </button>
+          )}
+        </div>
+      );
+    }
+
     return (
       <div className="rounded-lg border border-dashed border-border p-8 text-center">
         <Server className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />

--- a/src/components/skills/SkillList.tsx
+++ b/src/components/skills/SkillList.tsx
@@ -1,4 +1,4 @@
-import { Sparkles } from "lucide-react";
+import { Filter, Sparkles } from "lucide-react";
 import { useState } from "react";
 import type { SkillItem } from "@/types";
 import { SkillCard } from "./SkillCard";
@@ -6,12 +6,34 @@ import { SkillViewer } from "./SkillViewer";
 
 interface SkillListProps {
   skills: SkillItem[];
+  hasActiveFilters?: boolean;
+  onClearFilters?: () => void;
 }
 
-export function SkillList({ skills }: SkillListProps) {
+export function SkillList({ skills, hasActiveFilters, onClearFilters }: SkillListProps) {
   const [selectedSkill, setSelectedSkill] = useState<SkillItem | null>(null);
 
   if (skills.length === 0) {
+    if (hasActiveFilters) {
+      return (
+        <div className="rounded-lg border border-dashed border-border p-8 text-center">
+          <Filter className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+          <h3 className="font-medium">No Matching Skills</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            No skills match the current filters.
+          </p>
+          {onClearFilters && (
+            <button
+              onClick={onClearFilters}
+              className="mt-3 text-sm text-primary hover:underline"
+            >
+              Clear all filters
+            </button>
+          )}
+        </div>
+      );
+    }
+
     return (
       <div className="rounded-lg border border-dashed border-border p-8 text-center">
         <Sparkles className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />

--- a/src/pages/MCPs.tsx
+++ b/src/pages/MCPs.tsx
@@ -1,15 +1,23 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { RefreshCw, AlertCircle, FolderOpen, Plus } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { scanMCPs } from "@/lib/api/mcps";
 import { MCPList } from "@/components/mcps";
+import { FilterBar } from "@/components/filters";
 import { AddMCPDialog } from "@/components/sync";
 import { Button } from "@/components/ui/button";
+import type { SourceTool } from "@/types";
 
 export function MCPs() {
   const { current } = useWorkspaceStore();
   const [showAddDialog, setShowAddDialog] = useState(false);
+  const [activeTools, setActiveTools] = useState<SourceTool[]>([]);
+  const [activeScopes, setActiveScopes] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!current) setActiveScopes([]);
+  }, [current]);
 
   const {
     data: mcps,
@@ -21,6 +29,31 @@ export function MCPs() {
     queryKey: ["mcps", current?.repo_root ?? current?.path ?? null],
     queryFn: () => scanMCPs(current?.repo_root ?? current?.path),
   });
+
+  const filteredMcps = useMemo(() => {
+    if (!mcps) return [];
+    return mcps.filter((mcp) => {
+      if (
+        activeTools.length > 0 &&
+        !activeTools.some((t) => mcp.configuredIn.includes(t))
+      ) {
+        return false;
+      }
+      if (activeScopes.length > 0) {
+        const scopeValue =
+          mcp.scope === "project" || mcp.scope === "repo" ? "project" : "user";
+        if (!activeScopes.includes(scopeValue)) return false;
+      }
+      return true;
+    });
+  }, [mcps, activeTools, activeScopes]);
+
+  const hasActiveFilters = activeTools.length > 0 || activeScopes.length > 0;
+
+  function clearFilters() {
+    setActiveTools([]);
+    setActiveScopes([]);
+  }
 
   return (
     <div className="p-6">
@@ -61,6 +94,16 @@ export function MCPs() {
         </div>
       )}
 
+      {mcps && mcps.length > 0 && (
+        <FilterBar
+          activeTools={activeTools}
+          onToolsChange={setActiveTools}
+          activeScopes={activeScopes}
+          onScopesChange={setActiveScopes}
+          showScopeFilter={!!current}
+        />
+      )}
+
       {isLoading && (
         <div className="flex items-center justify-center py-12">
           <RefreshCw className="h-8 w-8 animate-spin text-muted-foreground" />
@@ -79,12 +122,19 @@ export function MCPs() {
         </div>
       )}
 
-      {mcps && <MCPList mcps={mcps} />}
+      {mcps && (
+        <MCPList
+          mcps={filteredMcps}
+          hasActiveFilters={hasActiveFilters}
+          onClearFilters={clearFilters}
+        />
+      )}
 
       {mcps && mcps.length > 0 && (
         <p className="mt-4 text-center text-xs text-muted-foreground">
-          Found {mcps.length} MCP server{mcps.length !== 1 ? "s" : ""} across
-          your configured tools
+          {filteredMcps.length === mcps.length
+            ? `Found ${mcps.length} MCP server${mcps.length !== 1 ? "s" : ""} across your configured tools`
+            : `Showing ${filteredMcps.length} of ${mcps.length} MCP server${mcps.length !== 1 ? "s" : ""}`}
         </p>
       )}
 

--- a/src/pages/Skills.tsx
+++ b/src/pages/Skills.tsx
@@ -1,15 +1,23 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { RefreshCw, AlertCircle, FolderOpen, Plus } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { scanSkills } from "@/lib/api/skills";
 import { SkillList, ConflictWarning } from "@/components/skills";
+import { FilterBar } from "@/components/filters";
 import { InstallSkillDialog } from "@/components/sync";
 import { Button } from "@/components/ui/button";
+import type { SourceTool } from "@/types";
 
 export function Skills() {
   const { current } = useWorkspaceStore();
   const [showInstallDialog, setShowInstallDialog] = useState(false);
+  const [activeTools, setActiveTools] = useState<SourceTool[]>([]);
+  const [activeScopes, setActiveScopes] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!current) setActiveScopes([]);
+  }, [current]);
 
   const {
     data: result,
@@ -21,6 +29,26 @@ export function Skills() {
     queryKey: ["skills", current?.repo_root ?? current?.path ?? null],
     queryFn: () => scanSkills(current?.repo_root ?? current?.path),
   });
+
+  const filteredSkills = useMemo(() => {
+    if (!result) return [];
+    return result.skills.filter((skill) => {
+      if (activeTools.length > 0 && !activeTools.includes(skill.sourceTool)) {
+        return false;
+      }
+      if (activeScopes.length > 0 && !activeScopes.includes(skill.scope)) {
+        return false;
+      }
+      return true;
+    });
+  }, [result, activeTools, activeScopes]);
+
+  const hasActiveFilters = activeTools.length > 0 || activeScopes.length > 0;
+
+  function clearFilters() {
+    setActiveTools([]);
+    setActiveScopes([]);
+  }
 
   return (
     <div className="p-6">
@@ -60,6 +88,16 @@ export function Skills() {
         </div>
       )}
 
+      {result && result.skills.length > 0 && (
+        <FilterBar
+          activeTools={activeTools}
+          onToolsChange={setActiveTools}
+          activeScopes={activeScopes}
+          onScopesChange={setActiveScopes}
+          showScopeFilter={!!current}
+        />
+      )}
+
       {isLoading && (
         <div className="flex items-center justify-center py-12">
           <RefreshCw className="h-8 w-8 animate-spin text-muted-foreground" />
@@ -81,14 +119,19 @@ export function Skills() {
       {result && (
         <>
           <ConflictWarning conflicts={result.conflicts} />
-          <SkillList skills={result.skills} />
+          <SkillList
+            skills={filteredSkills}
+            hasActiveFilters={hasActiveFilters}
+            onClearFilters={clearFilters}
+          />
         </>
       )}
 
       {result && result.skills.length > 0 && (
         <p className="mt-4 text-center text-xs text-muted-foreground">
-          Found {result.skills.length} skill
-          {result.skills.length !== 1 ? "s" : ""} across your configured tools
+          {filteredSkills.length === result.skills.length
+            ? `Found ${result.skills.length} skill${result.skills.length !== 1 ? "s" : ""} across your configured tools`
+            : `Showing ${filteredSkills.length} of ${result.skills.length} skill${result.skills.length !== 1 ? "s" : ""}`}
           {result.conflicts.length > 0 && (
             <span className="text-yellow-600">
               {" "}


### PR DESCRIPTION
## Summary

Added filtering capabilities to both MCPs and Skills pages, allowing users to filter items by tool (Claude, Codex, Gemini) and scope (User-level vs Project-level).

## Key Changes

- New `FilterBar` component with toggle buttons for tools and scopes
- Tool filters use configurable color coding (orange/green/blue)
- Scope filters only appear when a workspace is selected
- Filter-aware empty states with "Clear all filters" action
- Summary counts update to show "Showing X of Y" when filters are active
- Scope filters reset when workspace is deselected
- Fixed RuleViewer layout to prevent copy button clipping with empty content

## Implementation Details

- Tool filtering: MCPs check `configuredIn[]` array, Skills check `sourceTool` field
- Scope filtering: Both normalize `repo` and `project` scopes to single "project" toggle
- State management: Local `useState` per page for ephemeral filter state
- Filtering logic: OR within groups, AND between tool and scope filters