### PR TITLE
feat: Add scoped rules support

### DIFF
--- a/src-tauri/src/parsers/mod.rs
+++ b/src-tauri/src/parsers/mod.rs
@@ -1,7 +1,9 @@
 pub mod json_config;
+pub mod rules_frontmatter;
 pub mod skill_md;
 pub mod toml_config;
 
 pub use json_config::*;
+pub use rules_frontmatter::*;
 pub use skill_md::*;
 pub use toml_config::*;

--- a/src-tauri/src/parsers/rules_frontmatter.rs
+++ b/src-tauri/src/parsers/rules_frontmatter.rs
@@ -1,0 +1,156 @@
+//! Parser for YAML frontmatter in rule files (.claude/rules/*.md)
+//!
+//! Claude Code rules support a `paths:` field in YAML frontmatter to scope
+//! when the rule is loaded. Rules without `paths:` are loaded unconditionally.
+//!
+//! ```markdown
+//! ---
+//! paths:
+//!   - "src/domain/ai/**"
+//!   - "src/domain/agents/**"
+//! ---
+//! # AI Feature Development
+//! Instructions here...
+//! ```
+
+use serde::Deserialize;
+
+/// YAML frontmatter for a rule file
+#[derive(Debug, Deserialize)]
+struct RuleFrontmatter {
+    /// Glob patterns that scope when this rule is loaded
+    #[serde(default)]
+    paths: Option<Vec<String>>,
+}
+
+/// Parsed scoping info from a rule file
+#[derive(Debug, Clone)]
+pub struct ParsedRuleScoping {
+    /// Glob patterns from frontmatter. None = always loaded.
+    pub paths: Option<Vec<String>>,
+    /// The markdown content after stripping frontmatter
+    pub body: String,
+}
+
+/// Parse rule content for scoping frontmatter.
+/// Returns None for paths if no frontmatter or no `paths:` field.
+pub fn parse_rule_frontmatter(content: &str) -> ParsedRuleScoping {
+    let trimmed = content.trim();
+
+    if trimmed.starts_with("---") {
+        let after_first_delimiter = &trimmed[3..];
+        if let Some(end_pos) = after_first_delimiter.find("\n---") {
+            let frontmatter_str = after_first_delimiter[..end_pos].trim();
+            let body = after_first_delimiter[end_pos + 4..].trim().to_string();
+
+            if let Ok(fm) = serde_yaml::from_str::<RuleFrontmatter>(frontmatter_str) {
+                // Filter out empty paths lists
+                let paths = fm.paths.filter(|p| !p.is_empty());
+                return ParsedRuleScoping { paths, body };
+            }
+        }
+    }
+
+    // No frontmatter or parse failure: return content as-is, no scoping
+    ParsedRuleScoping {
+        paths: None,
+        body: content.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_paths_frontmatter() {
+        let content = r#"---
+paths:
+  - "src/domain/ai/**"
+  - "src/domain/agents/**"
+---
+# AI Rules
+Content here."#;
+        let result = parse_rule_frontmatter(content);
+        assert!(result.paths.is_some());
+        let paths = result.paths.unwrap();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0], "src/domain/ai/**");
+        assert_eq!(paths[1], "src/domain/agents/**");
+        assert!(result.body.contains("# AI Rules"));
+    }
+
+    #[test]
+    fn test_parse_no_paths_field() {
+        let content = r#"---
+description: Just a description
+---
+# Rules"#;
+        let result = parse_rule_frontmatter(content);
+        assert!(result.paths.is_none());
+        assert!(result.body.contains("# Rules"));
+    }
+
+    #[test]
+    fn test_parse_no_frontmatter() {
+        let content = "# Just markdown\nNo frontmatter here.";
+        let result = parse_rule_frontmatter(content);
+        assert!(result.paths.is_none());
+        assert_eq!(result.body, content);
+    }
+
+    #[test]
+    fn test_parse_empty_paths() {
+        let content = r#"---
+paths: []
+---
+# Rules"#;
+        let result = parse_rule_frontmatter(content);
+        assert!(result.paths.is_none()); // empty list treated as None
+    }
+
+    #[test]
+    fn test_parse_single_path() {
+        let content = r#"---
+paths:
+  - "src/**/*.ts"
+---
+# TypeScript rules"#;
+        let result = parse_rule_frontmatter(content);
+        assert!(result.paths.is_some());
+        let paths = result.paths.unwrap();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], "src/**/*.ts");
+    }
+
+    #[test]
+    fn test_parse_unclosed_frontmatter() {
+        let content = "---\npaths:\n  - \"src/**\"\n# Missing closing delimiter";
+        let result = parse_rule_frontmatter(content);
+        assert!(result.paths.is_none());
+        assert_eq!(result.body, content);
+    }
+
+    #[test]
+    fn test_parse_invalid_yaml() {
+        let content = "---\n: invalid yaml [[\n---\n# Rules";
+        let result = parse_rule_frontmatter(content);
+        // Invalid YAML falls through gracefully
+        assert!(result.paths.is_none());
+    }
+
+    #[test]
+    fn test_parse_brace_expansion_paths() {
+        let content = r#"---
+paths:
+  - "src/**/*.{ts,tsx}"
+  - "{src,lib}/**/*.ts"
+---
+# TypeScript rules"#;
+        let result = parse_rule_frontmatter(content);
+        assert!(result.paths.is_some());
+        let paths = result.paths.unwrap();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0], "src/**/*.{ts,tsx}");
+    }
+}

--- a/src-tauri/src/scanners/prompts.rs
+++ b/src-tauri/src/scanners/prompts.rs
@@ -44,6 +44,12 @@ pub struct PromptFile {
     pub content: String,
     /// File size in bytes
     pub size: u64,
+    /// Glob patterns that scope this rule (from frontmatter or directory path).
+    /// None means "always loaded" (unconditional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scoped_paths: Option<Vec<String>>,
+    /// Whether this rule is always loaded or conditionally scoped.
+    pub is_scoped: bool,
 }
 
 /// Result of scanning all system prompts
@@ -212,7 +218,16 @@ fn scan_rules_directory(
             .to_string_lossy()
             .to_string();
 
-        prompts.push(scan_prompt_file(&name, tool, scope, &path));
+        let mut prompt = scan_prompt_file(&name, tool, scope, &path);
+
+        // Parse frontmatter for scoping (Claude rules only — Gemini has no frontmatter support)
+        if tool == PromptSourceTool::Claude && prompt.exists && !prompt.content.is_empty() {
+            let scoping = crate::parsers::parse_rule_frontmatter(&prompt.content);
+            prompt.is_scoped = scoping.paths.is_some();
+            prompt.scoped_paths = scoping.paths;
+        }
+
+        prompts.push(prompt);
     }
 }
 
@@ -268,6 +283,8 @@ const PRUNE_DIRS: &[&str] = &[
 
 /// Target filenames to look for in subdirectories
 const SUBDIR_TARGETS: &[(&str, PromptSourceTool)] = &[
+    ("CLAUDE.md", PromptSourceTool::Claude),
+    ("CLAUDE.local.md", PromptSourceTool::Claude),
     ("AGENTS.md", PromptSourceTool::Codex),
     ("AGENTS.override.md", PromptSourceTool::Codex),
     ("GEMINI.md", PromptSourceTool::Gemini),
@@ -322,7 +339,23 @@ fn scan_subdirectory_rules(prompts: &mut Vec<PromptFile>, project_root: &Path) {
             .to_string_lossy()
             .to_string();
 
-        prompts.push(scan_prompt_file(&display_name, tool, PromptScope::Project, &path));
+        let mut prompt = scan_prompt_file(&display_name, tool, PromptScope::Project, &path);
+
+        // Derive directory-based scoping for all subdirectory rule files
+        if let Some(parent) = path.parent() {
+            let relative_dir = parent
+                .strip_prefix(project_root)
+                .unwrap_or(parent)
+                .to_string_lossy()
+                .to_string();
+            if !relative_dir.is_empty() {
+                let scope_glob = format!("{}/**", relative_dir);
+                prompt.scoped_paths = Some(vec![scope_glob]);
+                prompt.is_scoped = true;
+            }
+        }
+
+        prompts.push(prompt);
     }
 }
 
@@ -349,6 +382,8 @@ fn scan_prompt_file(name: &str, tool: PromptSourceTool, scope: PromptScope, path
         exists,
         content,
         size,
+        scoped_paths: None,
+        is_scoped: false,
     }
 }
 
@@ -370,6 +405,8 @@ mod tests {
         assert_eq!(result.name, "CLAUDE.md");
         assert!(result.content.contains("Be helpful"));
         assert!(result.size > 0);
+        assert!(!result.is_scoped);
+        assert!(result.scoped_paths.is_none());
     }
 
     #[test]
@@ -379,6 +416,7 @@ mod tests {
         assert!(!result.exists);
         assert!(result.content.is_empty());
         assert_eq!(result.size, 0);
+        assert!(!result.is_scoped);
     }
 
     #[test]
@@ -451,5 +489,106 @@ mod tests {
         assert!(names
             .iter()
             .any(|n| n.ends_with("payments/AGENTS.override.md")));
+    }
+
+    #[test]
+    fn test_frontmatter_scoped_rule() {
+        let dir = TempDir::new().unwrap();
+        let rules_dir = dir.path().join("rules");
+        fs::create_dir(&rules_dir).unwrap();
+
+        let scoped_content = "---\npaths:\n  - \"src/domain/ai/**\"\n  - \"src/lib/openai.ts\"\n---\n# AI Rules\nContent here.";
+        fs::write(rules_dir.join("ai-features.md"), scoped_content).unwrap();
+
+        let mut prompts = Vec::new();
+        scan_rules_directory(
+            &mut prompts,
+            PromptSourceTool::Claude,
+            PromptScope::Project,
+            &rules_dir,
+        );
+
+        assert_eq!(prompts.len(), 1);
+        let rule = &prompts[0];
+        assert!(rule.is_scoped);
+        assert!(rule.scoped_paths.is_some());
+        let paths = rule.scoped_paths.as_ref().unwrap();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0], "src/domain/ai/**");
+        assert_eq!(paths[1], "src/lib/openai.ts");
+    }
+
+    #[test]
+    fn test_no_frontmatter_rule_is_not_scoped() {
+        let dir = TempDir::new().unwrap();
+        let rules_dir = dir.path().join("rules");
+        fs::create_dir(&rules_dir).unwrap();
+
+        fs::write(rules_dir.join("general.md"), "# General rules\nAlways applies.").unwrap();
+
+        let mut prompts = Vec::new();
+        scan_rules_directory(
+            &mut prompts,
+            PromptSourceTool::Claude,
+            PromptScope::Project,
+            &rules_dir,
+        );
+
+        assert_eq!(prompts.len(), 1);
+        assert!(!prompts[0].is_scoped);
+        assert!(prompts[0].scoped_paths.is_none());
+    }
+
+    #[test]
+    fn test_gemini_rules_dir_no_frontmatter_parsing() {
+        let dir = TempDir::new().unwrap();
+        let rules_dir = dir.path().join("rules");
+        fs::create_dir(&rules_dir).unwrap();
+
+        // Gemini rules with paths: frontmatter should NOT be parsed
+        let content = "---\npaths:\n  - \"src/**\"\n---\n# Gemini rule";
+        fs::write(rules_dir.join("test.md"), content).unwrap();
+
+        let mut prompts = Vec::new();
+        scan_rules_directory(
+            &mut prompts,
+            PromptSourceTool::Gemini,
+            PromptScope::Project,
+            &rules_dir,
+        );
+
+        assert_eq!(prompts.len(), 1);
+        assert!(!prompts[0].is_scoped);
+        assert!(prompts[0].scoped_paths.is_none());
+    }
+
+    #[test]
+    fn test_subdirectory_scoping_derived() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+
+        // Create subdirectory with AGENTS.md
+        let api_dir = root.join("src").join("api");
+        fs::create_dir_all(&api_dir).unwrap();
+        fs::write(api_dir.join("AGENTS.md"), "# API rules").unwrap();
+
+        // Create subdirectory with CLAUDE.md
+        let backend_dir = root.join("src").join("backend");
+        fs::create_dir_all(&backend_dir).unwrap();
+        fs::write(backend_dir.join("CLAUDE.md"), "# Backend rules").unwrap();
+
+        let mut prompts = Vec::new();
+        scan_subdirectory_rules(&mut prompts, root);
+
+        // Both should be scoped
+        assert!(prompts.len() >= 2);
+
+        let agents = prompts.iter().find(|p| p.name.ends_with("api/AGENTS.md")).unwrap();
+        assert!(agents.is_scoped);
+        assert_eq!(agents.scoped_paths.as_ref().unwrap(), &vec!["src/api/**"]);
+
+        let claude = prompts.iter().find(|p| p.name.ends_with("backend/CLAUDE.md")).unwrap();
+        assert!(claude.is_scoped);
+        assert_eq!(claude.scoped_paths.as_ref().unwrap(), &vec!["src/backend/**"]);
     }
 }

--- a/src/components/config/PromptsSection.tsx
+++ b/src/components/config/PromptsSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FileText, Globe, FolderOpen } from "lucide-react";
+import { FileText, Globe, FolderOpen, Crosshair } from "lucide-react";
 import type { PromptFile } from "@/types";
 import { RuleCard } from "./RuleCard";
 import { RuleViewer } from "./RuleViewer";
@@ -14,6 +14,9 @@ export function PromptsSection({ prompts, workspaceName }: PromptsSectionProps) 
 
   const globalRules = prompts.filter((p) => p.scope === "global");
   const projectRules = prompts.filter((p) => p.scope === "project");
+  const alwaysLoadedProjectRules = projectRules.filter((p) => !p.isScoped);
+  const scopedProjectRules = projectRules.filter((p) => p.isScoped);
+  const hasBothTypes = alwaysLoadedProjectRules.length > 0 && scopedProjectRules.length > 0;
 
   if (prompts.length === 0) {
     return (
@@ -72,15 +75,45 @@ export function PromptsSection({ prompts, workspaceName }: PromptsSectionProps) 
               <FolderOpen className="h-3.5 w-3.5" />
               Project{workspaceName ? ` — ${workspaceName}` : ""}
             </h4>
-            <div className="space-y-2">
-              {projectRules.map((rule) => (
-                <RuleCard
-                  key={rule.path}
-                  rule={rule}
-                  onClick={() => rule.exists && setSelectedRule(rule)}
-                />
-              ))}
-            </div>
+
+            {/* Always loaded */}
+            {alwaysLoadedProjectRules.length > 0 && (
+              <div className={scopedProjectRules.length > 0 ? "mb-4" : ""}>
+                {hasBothTypes && (
+                  <p className="mb-2 text-xs text-muted-foreground">
+                    Always loaded
+                  </p>
+                )}
+                <div className="space-y-2">
+                  {alwaysLoadedProjectRules.map((rule) => (
+                    <RuleCard
+                      key={rule.path}
+                      rule={rule}
+                      onClick={() => rule.exists && setSelectedRule(rule)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Scoped */}
+            {scopedProjectRules.length > 0 && (
+              <div>
+                <p className="mb-2 flex items-center gap-1 text-xs text-muted-foreground">
+                  <Crosshair className="h-3 w-3" />
+                  Scoped — loaded when working on matching files
+                </p>
+                <div className="space-y-2">
+                  {scopedProjectRules.map((rule) => (
+                    <RuleCard
+                      key={rule.path}
+                      rule={rule}
+                      onClick={() => rule.exists && setSelectedRule(rule)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/components/config/RuleCard.tsx
+++ b/src/components/config/RuleCard.tsx
@@ -1,4 +1,4 @@
-import { FileText, ChevronRight } from "lucide-react";
+import { FileText, ChevronRight, Crosshair } from "lucide-react";
 import type { PromptFile } from "@/types";
 import { cn } from "@/lib/utils";
 import { ToolBadge } from "@/components/mcps/ToolBadge";
@@ -11,6 +11,11 @@ interface RuleCardProps {
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function formatScopedPaths(paths: string[]): string {
+  if (paths.length === 1) return paths[0];
+  return `${paths[0]} +${paths.length - 1} more`;
 }
 
 export function RuleCard({ rule, onClick }: RuleCardProps) {
@@ -36,9 +41,19 @@ export function RuleCard({ rule, onClick }: RuleCardProps) {
           <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
             {rule.scope}
           </span>
+          {rule.isScoped && (
+            <span className="inline-flex items-center gap-1 rounded-md border border-teal-500/20 bg-teal-500/10 px-1.5 py-0.5 text-[10px] font-medium text-teal-600 dark:text-teal-400">
+              <Crosshair className="h-2.5 w-2.5" />
+              scoped
+            </span>
+          )}
         </div>
         <p className="mt-0.5 truncate text-sm text-muted-foreground">
-          {rule.exists ? formatSize(rule.size) : "Not found"}
+          {rule.exists
+            ? rule.isScoped && rule.scopedPaths?.length
+              ? formatScopedPaths(rule.scopedPaths)
+              : formatSize(rule.size)
+            : "Not found"}
         </p>
       </div>
 

--- a/src/components/config/RuleViewer.tsx
+++ b/src/components/config/RuleViewer.tsx
@@ -1,4 +1,4 @@
-import { X, Copy, Check, FolderOpen } from "lucide-react";
+import { X, Copy, Check, FolderOpen, Crosshair } from "lucide-react";
 import { useState } from "react";
 import type { PromptFile } from "@/types";
 import { ToolBadge } from "@/components/mcps/ToolBadge";
@@ -29,6 +29,12 @@ export function RuleViewer({ rule, onClose }: RuleViewerProps) {
             <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground">
               {rule.scope}
             </span>
+            {rule.isScoped && (
+              <span className="inline-flex items-center gap-1 rounded-md border border-teal-500/20 bg-teal-500/10 px-1.5 py-0.5 text-[10px] font-medium text-teal-600 dark:text-teal-400">
+                <Crosshair className="h-2.5 w-2.5" />
+                scoped
+              </span>
+            )}
           </div>
           <button
             onClick={onClose}
@@ -38,6 +44,26 @@ export function RuleViewer({ rule, onClose }: RuleViewerProps) {
             <X className="h-5 w-5" />
           </button>
         </div>
+
+        {/* Scoping info */}
+        {rule.isScoped && rule.scopedPaths && rule.scopedPaths.length > 0 && (
+          <div className="border-b border-border bg-muted/30 px-4 py-2">
+            <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <Crosshair className="h-3 w-3" />
+              Applies when working on:
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {rule.scopedPaths.map((pattern) => (
+                <code
+                  key={pattern}
+                  className="rounded border border-teal-500/20 bg-teal-500/10 px-1.5 py-0.5 text-xs font-mono text-teal-600 dark:text-teal-400"
+                >
+                  {pattern}
+                </code>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Content */}
         <div className="relative min-h-[4rem] flex-1 overflow-auto">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -171,6 +171,10 @@ export interface PromptFile {
   exists: boolean;
   content: string;
   size: number;
+  /** Glob patterns that scope this rule. Undefined = always loaded. */
+  scopedPaths?: string[];
+  /** Whether this rule is conditionally scoped (true) or always loaded (false). */
+  isScoped: boolean;
 }
 
 export interface PromptScanResult {


### PR DESCRIPTION
## Summary
Implement path-based scoping for system rules across Claude Code, Codex, and Gemini. Rules can now be conditionally loaded based on file patterns (Claude frontmatter), directory placement (Codex/Gemini), or both.

## Changes
- **Backend**: New frontmatter parser, extended `PromptFile` with scoping fields, enhanced scanners to discover nested `CLAUDE.md` files and derive directory-based scoping
- **Frontend**: Display scoping badges, path patterns, and sub-group project rules by scoping type

## Tests
All 68 Rust tests pass. Frontend builds cleanly with no TypeScript errors.