### PR TITLE
feat: Context window visualization with MCP token estimation

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1856,6 +1856,7 @@ dependencies = [
  "dirs",
  "log",
  "reqwest 0.12.28",
+ "security-framework",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,5 +32,6 @@ serde_yaml = "0.9"
 walkdir = "2"
 tokio = { version = "1", features = ["fs", "process", "time"] }
 reqwest = { version = "0.12", features = ["json"] }
+security-framework = "2"
 tempfile = "3"
 chrono = "0.4"

--- a/src-tauri/src/commands/mcps.rs
+++ b/src-tauri/src/commands/mcps.rs
@@ -2,6 +2,7 @@
 
 use crate::parsers::{parse_claude_config, parse_codex_config, parse_gemini_config};
 use crate::scanners::mcps::{scan_all_mcps, HealthStatus, MCPItem};
+use crate::scanners::tokens::estimate_tokens;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -9,6 +10,9 @@ use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::timeout;
+
+#[cfg(target_os = "macos")]
+use security_framework::passwords::get_generic_password;
 
 /// Scan all MCP configurations from Claude Code, Codex CLI, and Gemini CLI
 #[tauri::command]
@@ -201,6 +205,465 @@ async fn test_stdio_mcp(
             message: "Health check timed out after 5 seconds".to_string(),
         }),
     }
+}
+
+// === MCP Tool Definition Fetching ===
+
+/// Information about a single MCP tool
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MCPToolInfo {
+    /// Tool name
+    pub name: String,
+    /// Tool description
+    pub description: Option<String>,
+    /// Estimated tokens for this tool's definition
+    pub tokens: u32,
+}
+
+/// Result of fetching MCP tool definitions
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MCPToolsResult {
+    /// Number of tools exposed by this MCP
+    pub tool_count: u32,
+    /// Total estimated idle tokens (all tool definitions)
+    pub idle_tokens: u32,
+    /// Individual tool information
+    pub tools: Vec<MCPToolInfo>,
+}
+
+/// Fetch tool definitions from an MCP server via tools/list JSON-RPC.
+/// This connects to the MCP, performs initialize + tools/list, then estimates token usage.
+/// When `use_keychain` is false, HTTP MCPs that need OAuth will fail with an auth error
+/// rather than prompting for Keychain access — letting the frontend show a consent UI first.
+#[tauri::command]
+pub async fn fetch_mcp_tools(
+    name: String,
+    mcp_type: String,
+    command: Option<String>,
+    args: Vec<String>,
+    url: Option<String>,
+    config_path: String,
+    use_keychain: bool,
+) -> Result<MCPToolsResult, String> {
+    let env = read_real_env(&name, &config_path)?;
+
+    match mcp_type.as_str() {
+        "stdio" => fetch_stdio_mcp_tools(command, args, env).await,
+        "http" => fetch_http_mcp_tools(&name, url, &config_path, use_keychain).await,
+        _ => Err(format!("Unknown MCP type: {}", mcp_type)),
+    }
+}
+
+/// Parse the tools/list response into MCPToolsResult
+fn parse_tools_response(response: &serde_json::Value) -> Result<MCPToolsResult, String> {
+    // Check for JSON-RPC error responses
+    if let Some(error) = response.get("error") {
+        let msg = error
+            .get("message")
+            .and_then(|m| m.as_str())
+            .or_else(|| error.as_str())
+            .unwrap_or("Unknown error");
+        return Err(format!("MCP returned error: {}", msg));
+    }
+
+    // Check for non-MCP error responses (e.g., HTTP auth errors)
+    if response.get("result").is_none() {
+        // Try to extract a meaningful error from the response
+        if let Some(err_desc) = response
+            .get("error_description")
+            .and_then(|d| d.as_str())
+        {
+            return Err(format!("Authentication failed: {}", err_desc));
+        }
+        return Err("Invalid response: no result from tools/list (server may require authentication)".to_string());
+    }
+
+    let empty_vec = vec![];
+    let tools_array = response
+        .get("result")
+        .and_then(|r| r.get("tools"))
+        .and_then(|t| t.as_array())
+        .unwrap_or(&empty_vec);
+
+    let mut tools = Vec::new();
+    let mut total_tokens: u32 = 0;
+
+    for tool in tools_array {
+        let name = tool
+            .get("name")
+            .and_then(|n| n.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let description = tool
+            .get("description")
+            .and_then(|d| d.as_str())
+            .map(|s| s.to_string());
+
+        // Estimate tokens from the serialized tool definition
+        // (name + description + inputSchema is what goes into context)
+        let tool_str = serde_json::to_string(tool).unwrap_or_default();
+        let tokens = estimate_tokens(&tool_str);
+        total_tokens += tokens;
+
+        tools.push(MCPToolInfo {
+            name,
+            description,
+            tokens,
+        });
+    }
+
+    // Sort by token count descending (biggest consumers first)
+    tools.sort_by(|a, b| b.tokens.cmp(&a.tokens));
+
+    Ok(MCPToolsResult {
+        tool_count: tools.len() as u32,
+        idle_tokens: total_tokens,
+        tools,
+    })
+}
+
+/// Fetch tool definitions from a stdio MCP
+async fn fetch_stdio_mcp_tools(
+    command: Option<String>,
+    args: Vec<String>,
+    env: HashMap<String, String>,
+) -> Result<MCPToolsResult, String> {
+    let cmd = command.ok_or("No command specified for stdio MCP")?;
+
+    let mut child = Command::new(&cmd)
+        .args(&args)
+        .envs(&env)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to spawn '{}': {}", cmd, e))?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or("Failed to open stdin for MCP process")?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("Failed to open stdout for MCP process")?;
+
+    let result = timeout(Duration::from_secs(10), async {
+        let mut writer = stdin;
+        let mut reader = BufReader::new(stdout);
+
+        // Step 1: Send initialize request
+        let init_request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "loadout-context-check",
+                    "version": "0.1.0"
+                }
+            }
+        });
+
+        let init_str = serde_json::to_string(&init_request)
+            .map_err(|e| format!("Failed to serialize init request: {}", e))?;
+        writer.write_all(init_str.as_bytes()).await
+            .map_err(|e| format!("Failed to write init request: {}", e))?;
+        writer.write_all(b"\n").await
+            .map_err(|e| format!("Failed to write newline: {}", e))?;
+        writer.flush().await
+            .map_err(|e| format!("Failed to flush: {}", e))?;
+
+        // Read initialize response
+        let mut line = String::new();
+        reader.read_line(&mut line).await
+            .map_err(|e| format!("Failed to read init response: {}", e))?;
+
+        if line.is_empty() {
+            return Err("No response from MCP server during initialize".to_string());
+        }
+
+        let init_response: serde_json::Value = serde_json::from_str(line.trim())
+            .map_err(|e| format!("Invalid init JSON response: {}", e))?;
+
+        if init_response.get("error").is_some() {
+            return Err("MCP server returned error during initialize".to_string());
+        }
+
+        // Step 2: Send tools/list request
+        let tools_request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        });
+
+        let tools_str = serde_json::to_string(&tools_request)
+            .map_err(|e| format!("Failed to serialize tools/list request: {}", e))?;
+        writer.write_all(tools_str.as_bytes()).await
+            .map_err(|e| format!("Failed to write tools/list request: {}", e))?;
+        writer.write_all(b"\n").await
+            .map_err(|e| format!("Failed to write newline: {}", e))?;
+        writer.flush().await
+            .map_err(|e| format!("Failed to flush: {}", e))?;
+
+        // Read tools/list response
+        let mut tools_line = String::new();
+        reader.read_line(&mut tools_line).await
+            .map_err(|e| format!("Failed to read tools/list response: {}", e))?;
+
+        if tools_line.is_empty() {
+            return Err("No response from MCP server for tools/list".to_string());
+        }
+
+        let tools_response: serde_json::Value = serde_json::from_str(tools_line.trim())
+            .map_err(|e| format!("Invalid tools/list JSON response: {}", e))?;
+
+        parse_tools_response(&tools_response)
+    })
+    .await;
+
+    let _ = child.kill().await;
+
+    match result {
+        Ok(inner) => inner,
+        Err(_) => Err("Tool fetch timed out after 10 seconds".to_string()),
+    }
+}
+
+/// Read real (unmasked) headers from the config file for a specific MCP.
+/// Also interpolates ${VAR} references using system environment variables.
+fn read_real_headers(name: &str, config_path: &str) -> HashMap<String, String> {
+    let path = Path::new(config_path);
+    if !path.exists() {
+        return HashMap::new();
+    }
+
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let raw_headers = match ext {
+        "json" => {
+            let file_name = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+            if file_name == "settings.json" {
+                parse_gemini_config(path)
+                    .ok()
+                    .and_then(|c| c.mcp_servers.get(name).map(|s| s.headers.clone()))
+                    .unwrap_or_default()
+            } else {
+                parse_claude_config(path)
+                    .ok()
+                    .and_then(|c| c.mcp_servers.get(name).map(|s| s.headers.clone()))
+                    .unwrap_or_default()
+            }
+        }
+        _ => HashMap::new(),
+    };
+
+    // Interpolate ${VAR} references
+    raw_headers
+        .into_iter()
+        .map(|(k, v)| {
+            let resolved = interpolate_env_vars(&v);
+            (k, resolved)
+        })
+        .collect()
+}
+
+/// Interpolate ${VAR} references in a string using system env vars
+fn interpolate_env_vars(value: &str) -> String {
+    let mut result = value.to_string();
+    // Find all ${VAR} patterns and replace with env var values
+    while let Some(start) = result.find("${") {
+        if let Some(end) = result[start..].find('}') {
+            let var_name = &result[start + 2..start + end];
+            let replacement = std::env::var(var_name).unwrap_or_default();
+            result = format!("{}{}{}", &result[..start], replacement, &result[start + end + 1..]);
+        } else {
+            break;
+        }
+    }
+    result
+}
+
+/// Try to read an OAuth token for an HTTP MCP from Claude Code's Keychain storage.
+/// Claude Code stores MCP OAuth tokens in the macOS Keychain under "Claude Code-credentials".
+#[cfg(target_os = "macos")]
+fn read_keychain_oauth_token(server_name: &str) -> Option<String> {
+    let username = std::env::var("USER").unwrap_or_default();
+    if username.is_empty() {
+        return None;
+    }
+
+    let password_bytes = get_generic_password("Claude Code-credentials", &username).ok()?;
+    let json_str = std::str::from_utf8(&password_bytes).ok()?;
+    let creds: serde_json::Value = serde_json::from_str(json_str).ok()?;
+
+    let mcp_oauth = creds.get("mcpOAuth")?;
+    // Keys are formatted as "{serverName}|{hash}", find by prefix
+    for (key, entry) in mcp_oauth.as_object()? {
+        if !key.starts_with(&format!("{}|", server_name)) {
+            continue;
+        }
+        let access_token = entry.get("accessToken")?.as_str()?;
+        if access_token.is_empty() {
+            return None; // Token exists but is empty (expired)
+        }
+        // Check expiry
+        let expires_at = entry.get("expiresAt")?.as_u64()?;
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()?
+            .as_millis() as u64;
+        if expires_at > 0 && now_ms > expires_at {
+            return None; // Token expired
+        }
+        return Some(access_token.to_string());
+    }
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_keychain_oauth_token(_server_name: &str) -> Option<String> {
+    None // Keychain only available on macOS
+}
+
+/// Fetch tool definitions from an HTTP MCP.
+/// When `use_keychain` is false, skips Keychain OAuth lookup — auth errors will surface
+/// to the frontend so it can show a consent prompt before requesting Keychain access.
+async fn fetch_http_mcp_tools(
+    name: &str,
+    url: Option<String>,
+    config_path: &str,
+    use_keychain: bool,
+) -> Result<MCPToolsResult, String> {
+    let endpoint = url.ok_or("No URL specified for HTTP MCP")?;
+
+    // Resolve auth: config headers > Keychain OAuth (if allowed) > none
+    let config_headers = read_real_headers(name, config_path);
+    let has_auth_header = config_headers.keys().any(|k| k.to_lowercase() == "authorization");
+
+    let oauth_token = if !has_auth_header && use_keychain {
+        read_keychain_oauth_token(name)
+    } else {
+        None
+    };
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    // Helper to add auth headers to a request
+    let add_auth = |mut req: reqwest::RequestBuilder| -> reqwest::RequestBuilder {
+        // Add config headers first
+        for (key, value) in &config_headers {
+            req = req.header(key.as_str(), value.as_str());
+        }
+        // Add OAuth token if no Authorization header from config
+        if !has_auth_header {
+            if let Some(ref token) = oauth_token {
+                req = req.header("Authorization", format!("Bearer {}", token));
+            }
+        }
+        req
+    };
+
+    // Step 1: Initialize
+    let init_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "loadout-context-check",
+                "version": "0.1.0"
+            }
+        }
+    });
+
+    let req = client
+        .post(&endpoint)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&init_request);
+    let init_response = add_auth(req)
+        .send()
+        .await
+        .map_err(|e| format!("Initialize request failed: {}", e))?;
+
+    let status = init_response.status().as_u16();
+    if status == 401 || status == 403 {
+        if oauth_token.is_none() && !has_auth_header {
+            return Err(format!(
+                "Authentication required (HTTP {}). Re-authenticate via Claude Code or add headers to your MCP config.",
+                status
+            ));
+        }
+        return Err(format!("Authentication failed (HTTP {}). Token may be expired — re-authenticate via Claude Code.", status));
+    }
+    if !init_response.status().is_success() {
+        return Err(format!("Initialize failed with HTTP {}", status));
+    }
+
+    // Try to extract session ID from response headers for session continuity
+    let session_id = init_response
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    // Consume init response body (needed before next request)
+    let _ = init_response.text().await;
+
+    // Step 2: Send tools/list
+    let tools_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {}
+    });
+
+    let mut req = client
+        .post(&endpoint)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&tools_request);
+
+    if let Some(ref sid) = session_id {
+        req = req.header("mcp-session-id", sid);
+    }
+
+    let tools_response = add_auth(req)
+        .send()
+        .await
+        .map_err(|e| format!("tools/list request failed: {}", e))?;
+
+    let body = tools_response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read tools/list response body: {}", e))?;
+
+    // Handle SSE responses (text/event-stream) — extract JSON from data lines
+    let json_str = if body.starts_with("data:") || body.contains("\ndata:") {
+        body.lines()
+            .filter(|l| l.starts_with("data:"))
+            .map(|l| l.strip_prefix("data:").unwrap_or(l).trim())
+            .find(|l| !l.is_empty())
+            .unwrap_or(&body)
+            .to_string()
+    } else {
+        body
+    };
+
+    let response: serde_json::Value = serde_json::from_str(&json_str)
+        .map_err(|e| format!("Invalid tools/list JSON: {}", e))?;
+
+    parse_tools_response(&response)
 }
 
 /// Test an HTTP MCP by sending a JSON-RPC initialize request via POST.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,8 +10,8 @@ mod workspace;
 mod writers;
 
 use commands::{
-    add_mcp_to_tools, install_skill_to_tools, preview_mcp_configs, scan_hooks, scan_mcps,
-    scan_rules, scan_skills, sync_mcp_to_tools, test_mcp_health,
+    add_mcp_to_tools, fetch_mcp_tools, install_skill_to_tools, preview_mcp_configs, scan_hooks,
+    scan_mcps, scan_rules, scan_skills, sync_mcp_to_tools, test_mcp_health,
 };
 use scanners::workspaces::{discover_workspaces, DiscoveryResult};
 
@@ -111,6 +111,7 @@ pub fn run() {
             install_skill_to_tools,
             sync_mcp_to_tools,
             test_mcp_health,
+            fetch_mcp_tools,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/parsers/json_config.rs
+++ b/src-tauri/src/parsers/json_config.rs
@@ -24,6 +24,9 @@ pub struct JsonMCPServer {
     /// Environment variables
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// HTTP headers (for http type, supports ${VAR} interpolation)
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
 }
 
 fn default_mcp_type() -> String {

--- a/src-tauri/src/scanners/mcps.rs
+++ b/src-tauri/src/scanners/mcps.rs
@@ -57,6 +57,8 @@ pub struct MCPItem {
     pub url: Option<String>,
     /// Environment variables (values masked)
     pub env: HashMap<String, String>,
+    /// HTTP headers (for http type, values masked)
+    pub headers: HashMap<String, String>,
     /// Which tools this MCP is configured in
     pub configured_in: Vec<SourceTool>,
     /// Scope (user or project level)
@@ -76,6 +78,7 @@ struct RawMCPEntry {
     args: Vec<String>,
     url: Option<String>,
     env: HashMap<String, String>,
+    headers: HashMap<String, String>,
     source_tool: SourceTool,
     scope: Scope,
     path: String,
@@ -103,6 +106,7 @@ pub fn scan_all_mcps(workspace_path: Option<&str>) -> Result<Vec<MCPItem>, Strin
                 args: server.args,
                 url: server.url,
                 env: server.env,
+                headers: server.headers,
                 source_tool: SourceTool::Claude,
                 scope: Scope::User,
                 path: claude_user_path.to_string_lossy().to_string(),
@@ -127,6 +131,7 @@ pub fn scan_all_mcps(workspace_path: Option<&str>) -> Result<Vec<MCPItem>, Strin
                     args: server.args,
                     url: server.url,
                     env: server.env,
+                    headers: server.headers,
                     source_tool: SourceTool::Claude,
                     scope: Scope::Project,
                     path: project_mcp_path.to_string_lossy().to_string(),
@@ -147,6 +152,7 @@ pub fn scan_all_mcps(workspace_path: Option<&str>) -> Result<Vec<MCPItem>, Strin
                 args: server.args,
                 url: None,
                 env: server.env,
+                headers: HashMap::new(),
                 source_tool: SourceTool::Codex,
                 scope: Scope::User,
                 path: codex_config_path.to_string_lossy().to_string(),
@@ -171,6 +177,7 @@ pub fn scan_all_mcps(workspace_path: Option<&str>) -> Result<Vec<MCPItem>, Strin
                 args: server.args,
                 url: server.url,
                 env: server.env,
+                headers: server.headers,
                 source_tool: SourceTool::Gemini,
                 scope: Scope::User,
                 path: gemini_config_path.to_string_lossy().to_string(),
@@ -190,6 +197,7 @@ fn merge_mcp_entries(entries: Vec<RawMCPEntry>) -> Vec<MCPItem> {
 
     for entry in entries {
         let masked_env = mask_env_values(&entry.env);
+        let masked_headers = mask_env_values(&entry.headers);
 
         if let Some(existing) = by_name.get_mut(&entry.name) {
             // Add this tool to the list if not already present
@@ -214,6 +222,7 @@ fn merge_mcp_entries(entries: Vec<RawMCPEntry>) -> Vec<MCPItem> {
                     args: entry.args,
                     url: entry.url,
                     env: masked_env,
+                    headers: masked_headers,
                     configured_in: vec![entry.source_tool],
                     scope: entry.scope,
                     path: entry.path,
@@ -259,6 +268,7 @@ mod tests {
                 args: vec!["-y".to_string(), "@github/mcp-server".to_string()],
                 url: None,
                 env: HashMap::new(),
+                headers: HashMap::new(),
                 source_tool: SourceTool::Claude,
                 scope: Scope::User,
                 path: "/path/to/claude.json".to_string(),
@@ -270,6 +280,7 @@ mod tests {
                 args: vec!["-y".to_string(), "@github/mcp-server".to_string()],
                 url: None,
                 env: HashMap::new(),
+                headers: HashMap::new(),
                 source_tool: SourceTool::Codex,
                 scope: Scope::User,
                 path: "/path/to/config.toml".to_string(),
@@ -292,6 +303,7 @@ mod tests {
             args: vec![],
             url: Some("https://mcp.linear.app/mcp".to_string()),
             env: HashMap::new(),
+            headers: HashMap::new(),
             source_tool: SourceTool::Claude,
             scope: Scope::User,
             path: "/path/to/claude.json".to_string(),

--- a/src-tauri/src/scanners/mod.rs
+++ b/src-tauri/src/scanners/mod.rs
@@ -2,4 +2,5 @@ pub mod hooks;
 pub mod mcps;
 pub mod prompts;
 pub mod skills;
+pub mod tokens;
 pub mod workspaces;

--- a/src-tauri/src/scanners/prompts.rs
+++ b/src-tauri/src/scanners/prompts.rs
@@ -3,6 +3,7 @@
 //! Scans main prompt files (CLAUDE.md, AGENTS.md, GEMINI.md) and rules directories
 //! at both global and project levels.
 
+use super::tokens::estimate_tokens;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
@@ -44,6 +45,8 @@ pub struct PromptFile {
     pub content: String,
     /// File size in bytes
     pub size: u64,
+    /// Estimated token count for context window usage
+    pub tokens: u32,
     /// Glob patterns that scope this rule (from frontmatter or directory path).
     /// None means "always loaded" (unconditional).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -374,6 +377,8 @@ fn scan_prompt_file(name: &str, tool: PromptSourceTool, scope: PromptScope, path
         (String::new(), 0)
     };
 
+    let tokens = estimate_tokens(&content);
+
     PromptFile {
         name: name.to_string(),
         source_tool: tool,
@@ -382,6 +387,7 @@ fn scan_prompt_file(name: &str, tool: PromptSourceTool, scope: PromptScope, path
         exists,
         content,
         size,
+        tokens,
         scoped_paths: None,
         is_scoped: false,
     }

--- a/src-tauri/src/scanners/skills.rs
+++ b/src-tauri/src/scanners/skills.rs
@@ -3,6 +3,7 @@
 //! Scans all skill paths and returns a unified list with maturity badges,
 //! conflict detection, and shadowing information.
 
+use super::tokens::estimate_tokens;
 use crate::parsers::parse_skill_md;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
@@ -56,6 +57,10 @@ pub struct SkillItem {
     pub maturity: SkillMaturity,
     /// Absolute path to the SKILL.md file
     pub path: String,
+    /// Estimated tokens when idle (just name + description in skill listing)
+    pub idle_tokens: u32,
+    /// Estimated tokens when actively invoked (full content)
+    pub active_tokens: u32,
     /// True if this skill is shadowed by a higher-precedence skill
     pub is_shadowed: bool,
     /// Path of the skill that shadows this one
@@ -320,6 +325,12 @@ fn process_skill_entries(entries: Vec<RawSkillEntry>) -> (Vec<SkillItem>, Vec<Sk
 
         let id = generate_skill_id(&entry.name, entry.source_tool, entry.scope);
 
+        // Estimate tokens: idle = name + description (as listed in skill menu),
+        // active = full content (loaded when skill is invoked)
+        let idle_text = format!("{}: {}", &entry.name, &entry.description);
+        let idle_tokens = estimate_tokens(&idle_text);
+        let active_tokens = estimate_tokens(&entry.content);
+
         skills.push(SkillItem {
             id,
             name: entry.name,
@@ -329,6 +340,8 @@ fn process_skill_entries(entries: Vec<RawSkillEntry>) -> (Vec<SkillItem>, Vec<Sk
             scope: entry.scope,
             maturity,
             path: entry.path,
+            idle_tokens,
+            active_tokens,
             is_shadowed,
             shadowed_by,
         });

--- a/src-tauri/src/scanners/tokens.rs
+++ b/src-tauri/src/scanners/tokens.rs
@@ -1,0 +1,52 @@
+//! Token estimation utilities for context window usage tracking.
+//!
+//! Uses a simple heuristic of ~4 characters per token, which is within
+//! ~10-15% of actual BPE tokenization for English text and code.
+
+/// Estimate the number of tokens in a text string.
+///
+/// Uses the heuristic of approximately 4 characters per token.
+/// Returns 0 for empty strings.
+pub fn estimate_tokens(text: &str) -> u32 {
+    if text.is_empty() {
+        return 0;
+    }
+    ((text.len() as f64) / 4.0).ceil() as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_string() {
+        assert_eq!(estimate_tokens(""), 0);
+    }
+
+    #[test]
+    fn test_short_string() {
+        // "hello" = 5 chars → ceil(5/4) = 2
+        assert_eq!(estimate_tokens("hello"), 2);
+    }
+
+    #[test]
+    fn test_exact_multiple() {
+        // 8 chars → ceil(8/4) = 2
+        assert_eq!(estimate_tokens("abcdefgh"), 2);
+    }
+
+    #[test]
+    fn test_longer_content() {
+        // 100 chars → ceil(100/4) = 25
+        let text = "a".repeat(100);
+        assert_eq!(estimate_tokens(&text), 25);
+    }
+
+    #[test]
+    fn test_not_exact_multiple() {
+        // 5 chars → ceil(5/4) = 2
+        assert_eq!(estimate_tokens("abcde"), 2);
+        // 9 chars → ceil(9/4) = 3
+        assert_eq!(estimate_tokens("abcdefghi"), 3);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { MCPs } from "@/pages/MCPs";
 import { Skills } from "@/pages/Skills";
 import { Rules } from "@/pages/Rules";
 import { Hooks } from "@/pages/Hooks";
+import { Context } from "@/pages/Context";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 function App() {
@@ -19,6 +20,8 @@ function App() {
         return <Rules />;
       case "hooks":
         return <Hooks />;
+      case "context":
+        return <Context />;
       default:
         return <MCPs />;
     }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,262 +1,33 @@
-import {
-  FolderOpen,
-  ChevronDown,
-  GitBranch,
-  Search,
-  RefreshCw,
-} from "lucide-react";
-import { open } from "@tauri-apps/plugin-dialog";
-import { Button } from "@/components/ui/button";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import { getWorkspaceInfo, discoverWorkspaces } from "@/lib/api/workspace";
-import { useState, useEffect, useRef } from "react";
-import { useQuery } from "@tanstack/react-query";
-import type { DiscoveredWorkspace } from "@/types";
-import { cn } from "@/lib/utils";
+import { FolderOpen, GitBranch } from "lucide-react";
 
-const toolColors: Record<string, string> = {
-  claude: "bg-orange-500",
-  codex: "bg-green-500",
-  gemini: "bg-blue-500",
+const tabLabels: Record<string, string> = {
+  mcps: "MCPs",
+  skills: "Skills",
+  rules: "Rules",
+  hooks: "Hooks",
+  context: "Context",
 };
 
-function ToolDots({ workspace }: { workspace: DiscoveredWorkspace }) {
-  const tools: { name: string; active: boolean }[] = [
-    {
-      name: "claude",
-      active:
-        workspace.signals.hasClaudeConfig ||
-        workspace.signals.hasClaudePrompt ||
-        workspace.signals.hasClaudeSkills,
-    },
-    {
-      name: "codex",
-      active:
-        workspace.signals.hasCodexConfig ||
-        workspace.signals.hasCodexPrompt ||
-        workspace.signals.hasCodexSkills,
-    },
-    {
-      name: "gemini",
-      active:
-        workspace.signals.hasGeminiConfig ||
-        workspace.signals.hasGeminiPrompt ||
-        workspace.signals.hasGeminiSkills,
-    },
-  ];
-
-  return (
-    <div className="flex items-center gap-1">
-      {tools
-        .filter((t) => t.active)
-        .map((t) => (
-          <span
-            key={t.name}
-            className={cn("h-2 w-2 rounded-full", toolColors[t.name])}
-            title={t.name}
-          />
-        ))}
-    </div>
-  );
-}
-
 export function Header() {
-  const { current, setCurrent } = useWorkspaceStore();
-  const [showDropdown, setShowDropdown] = useState(false);
-  const [filter, setFilter] = useState("");
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  // Auto-discover workspaces on mount
-  const {
-    data: discovery,
-    isLoading: isDiscovering,
-    refetch: rescan,
-    isRefetching,
-  } = useQuery({
-    queryKey: ["discover-workspaces"],
-    queryFn: () => discoverWorkspaces(4),
-    staleTime: 5 * 60 * 1000, // Cache for 5 min
-  });
-
-  // Close dropdown on outside click
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      ) {
-        setShowDropdown(false);
-      }
-    }
-    if (showDropdown) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () =>
-        document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [showDropdown]);
-
-  const handleSelectFolder = async () => {
-    const selected = await open({
-      directory: true,
-      multiple: false,
-      title: "Select Workspace",
-    });
-
-    if (selected && typeof selected === "string") {
-      const info = await getWorkspaceInfo(selected);
-      setCurrent(info);
-      setShowDropdown(false);
-    }
-  };
-
-  const handleSelectWorkspace = async (path: string) => {
-    const info = await getWorkspaceInfo(path);
-    setCurrent(info);
-    setShowDropdown(false);
-    setFilter("");
-  };
-
-  const filteredWorkspaces =
-    discovery?.workspaces.filter(
-      (ws) =>
-        !filter ||
-        ws.name.toLowerCase().includes(filter.toLowerCase()) ||
-        ws.path.toLowerCase().includes(filter.toLowerCase())
-    ) ?? [];
+  const { activeTab, current } = useWorkspaceStore();
 
   return (
     <header className="flex h-14 items-center justify-between border-b border-border bg-card px-4">
-      {/* Current workspace indicator */}
-      <div className="flex items-center gap-2">
-        {current ? (
-          <div className="flex items-center gap-2">
-            <FolderOpen className="h-4 w-4 text-muted-foreground" />
-            <span className="font-medium">{current.name}</span>
-            {current.repo_root && (
-              <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                <GitBranch className="h-3 w-3" />
-                git
-              </span>
-            )}
-          </div>
-        ) : (
-          <span className="text-muted-foreground">No workspace selected</span>
-        )}
-      </div>
+      <h2 className="text-lg font-semibold">{tabLabels[activeTab]}</h2>
 
-      {/* Workspace selector */}
-      <div className="relative" ref={dropdownRef}>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={handleSelectFolder}>
-            <FolderOpen className="mr-2 h-4 w-4" />
-            Browse
-          </Button>
-
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setShowDropdown(!showDropdown);
-              setFilter("");
-            }}
-          >
-            <Search className="mr-2 h-4 w-4" />
-            Workspaces
-            {discovery && (
-              <span className="ml-1.5 rounded-full bg-muted px-1.5 text-[10px] font-medium">
-                {discovery.workspaces.length}
-              </span>
-            )}
-            <ChevronDown className="ml-1 h-3 w-3" />
-          </Button>
+      {current && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <FolderOpen className="h-3.5 w-3.5" />
+          <span>{current.name}</span>
+          {current.repo_root && (
+            <span className="flex items-center gap-1 text-xs">
+              <GitBranch className="h-3 w-3" />
+              git
+            </span>
+          )}
         </div>
-
-        {/* Workspace discovery dropdown */}
-        {showDropdown && (
-          <div className="absolute right-0 top-full z-50 mt-1 w-96 rounded-md border border-border bg-card shadow-lg">
-            {/* Search filter */}
-            <div className="border-b border-border px-3 py-2">
-              <input
-                type="text"
-                placeholder="Filter workspaces..."
-                value={filter}
-                onChange={(e) => setFilter(e.target.value)}
-                className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-                autoFocus
-              />
-            </div>
-
-            {/* Discovered workspaces */}
-            <div className="max-h-80 overflow-auto py-1">
-              {isDiscovering ? (
-                <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-                  <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
-                  Scanning...
-                </div>
-              ) : filteredWorkspaces.length === 0 ? (
-                <p className="px-3 py-4 text-center text-sm text-muted-foreground">
-                  {filter
-                    ? "No matching workspaces"
-                    : "No AI CLI workspaces found"}
-                </p>
-              ) : (
-                filteredWorkspaces.map((ws) => {
-                  const isActive =
-                    current?.path === ws.path ||
-                    current?.repo_root === ws.path;
-                  return (
-                    <button
-                      key={ws.path}
-                      onClick={() => handleSelectWorkspace(ws.path)}
-                      className={cn(
-                        "flex w-full items-center gap-3 px-3 py-2 text-left text-sm hover:bg-accent",
-                        isActive && "bg-accent"
-                      )}
-                    >
-                      <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2">
-                          <span className="truncate font-medium">
-                            {ws.name}
-                          </span>
-                          {ws.isGitRepo && (
-                            <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
-                          )}
-                          <ToolDots workspace={ws} />
-                        </div>
-                        <p
-                          className="truncate text-xs text-muted-foreground"
-                          title={ws.path}
-                        >
-                          {ws.path.replace(/^\/Users\/[^/]+/, "~")}
-                        </p>
-                      </div>
-                    </button>
-                  );
-                })
-              )}
-            </div>
-
-            {/* Footer with rescan + stats */}
-            <div className="flex items-center justify-between border-t border-border px-3 py-1.5">
-              <span className="text-[10px] text-muted-foreground">
-                {discovery &&
-                  `${discovery.workspaces.length} found in ${discovery.scanDurationMs}ms`}
-              </span>
-              <button
-                onClick={() => rescan()}
-                disabled={isRefetching}
-                className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground"
-              >
-                <RefreshCw
-                  className={cn("h-3 w-3", isRefetching && "animate-spin")}
-                />
-                Rescan
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
+      )}
     </header>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,16 +1,146 @@
-import { Server, Sparkles, FileText, Anchor } from "lucide-react";
+import {
+  Server,
+  Sparkles,
+  FileText,
+  Anchor,
+  BarChart3,
+  FolderOpen,
+  ChevronDown,
+  GitBranch,
+  Search,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import { open } from "@tauri-apps/plugin-dialog";
 import { cn } from "@/lib/utils";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { getWorkspaceInfo, discoverWorkspaces } from "@/lib/api/workspace";
+import { useState, useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { DiscoveredWorkspace } from "@/types";
 
 const navItems = [
   { id: "mcps" as const, label: "MCPs", icon: Server },
   { id: "skills" as const, label: "Skills", icon: Sparkles },
   { id: "rules" as const, label: "Rules", icon: FileText },
   { id: "hooks" as const, label: "Hooks", icon: Anchor },
+  { id: "context" as const, label: "Context", icon: BarChart3 },
 ];
 
+const toolColors: Record<string, string> = {
+  claude: "bg-orange-500",
+  codex: "bg-green-500",
+  gemini: "bg-blue-500",
+};
+
+function ToolDots({ workspace }: { workspace: DiscoveredWorkspace }) {
+  const tools: { name: string; active: boolean }[] = [
+    {
+      name: "claude",
+      active:
+        workspace.signals.hasClaudeConfig ||
+        workspace.signals.hasClaudePrompt ||
+        workspace.signals.hasClaudeSkills,
+    },
+    {
+      name: "codex",
+      active:
+        workspace.signals.hasCodexConfig ||
+        workspace.signals.hasCodexPrompt ||
+        workspace.signals.hasCodexSkills,
+    },
+    {
+      name: "gemini",
+      active:
+        workspace.signals.hasGeminiConfig ||
+        workspace.signals.hasGeminiPrompt ||
+        workspace.signals.hasGeminiSkills,
+    },
+  ];
+
+  return (
+    <div className="flex items-center gap-1">
+      {tools
+        .filter((t) => t.active)
+        .map((t) => (
+          <span
+            key={t.name}
+            className={cn("h-2 w-2 rounded-full", toolColors[t.name])}
+            title={t.name}
+          />
+        ))}
+    </div>
+  );
+}
+
 export function Sidebar() {
-  const { activeTab, setActiveTab } = useWorkspaceStore();
+  const { activeTab, setActiveTab, current, setCurrent } =
+    useWorkspaceStore();
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [filter, setFilter] = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const {
+    data: discovery,
+    isLoading: isDiscovering,
+    refetch: rescan,
+    isRefetching,
+  } = useQuery({
+    queryKey: ["discover-workspaces"],
+    queryFn: () => discoverWorkspaces(4),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setShowDropdown(false);
+      }
+    }
+    if (showDropdown) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [showDropdown]);
+
+  const handleSelectFolder = async () => {
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      title: "Select Workspace",
+    });
+
+    if (selected && typeof selected === "string") {
+      const info = await getWorkspaceInfo(selected);
+      setCurrent(info);
+      setShowDropdown(false);
+    }
+  };
+
+  const handleSelectWorkspace = async (path: string) => {
+    const info = await getWorkspaceInfo(path);
+    setCurrent(info);
+    setShowDropdown(false);
+    setFilter("");
+  };
+
+  const handleClearWorkspace = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setCurrent(null);
+  };
+
+  const filteredWorkspaces =
+    discovery?.workspaces.filter(
+      (ws) =>
+        !filter ||
+        ws.name.toLowerCase().includes(filter.toLowerCase()) ||
+        ws.path.toLowerCase().includes(filter.toLowerCase())
+    ) ?? [];
 
   return (
     <aside className="flex h-full w-[200px] flex-col border-r border-sidebar-border bg-sidebar">
@@ -19,6 +149,126 @@ export function Sidebar() {
         <h1 className="text-lg font-semibold tracking-tight text-sidebar-foreground">
           Loadout
         </h1>
+      </div>
+
+      {/* Workspace selector */}
+      <div className="relative border-b border-sidebar-border p-2" ref={dropdownRef}>
+        <button
+          onClick={() => {
+            setShowDropdown(!showDropdown);
+            setFilter("");
+          }}
+          className={cn(
+            "flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
+            "hover:bg-sidebar-accent/50",
+            current
+              ? "text-sidebar-foreground"
+              : "text-muted-foreground"
+          )}
+        >
+          <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate text-left">
+            {current ? current.name : "Select workspace"}
+          </span>
+          {current ? (
+            <X
+              className="h-3.5 w-3.5 shrink-0 text-muted-foreground hover:text-foreground"
+              onClick={handleClearWorkspace}
+            />
+          ) : (
+            <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+          )}
+        </button>
+
+        {/* Dropdown */}
+        {showDropdown && (
+          <div className="absolute left-2 right-2 top-full z-50 mt-1 rounded-md border border-border bg-card shadow-lg">
+            {/* Search filter */}
+            <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+              <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <input
+                type="text"
+                placeholder="Filter workspaces..."
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                autoFocus
+              />
+            </div>
+
+            {/* Workspace list */}
+            <div className="max-h-64 overflow-auto py-1">
+              {isDiscovering ? (
+                <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+                  <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
+                  Scanning...
+                </div>
+              ) : filteredWorkspaces.length === 0 ? (
+                <p className="px-3 py-4 text-center text-sm text-muted-foreground">
+                  {filter
+                    ? "No matching workspaces"
+                    : "No AI CLI workspaces found"}
+                </p>
+              ) : (
+                filteredWorkspaces.map((ws) => {
+                  const isActive =
+                    current?.path === ws.path ||
+                    current?.repo_root === ws.path;
+                  return (
+                    <button
+                      key={ws.path}
+                      onClick={() => handleSelectWorkspace(ws.path)}
+                      className={cn(
+                        "flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent",
+                        isActive && "bg-accent"
+                      )}
+                    >
+                      <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-1.5">
+                          <span className="truncate font-medium text-xs">
+                            {ws.name}
+                          </span>
+                          {ws.isGitRepo && (
+                            <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+                          )}
+                          <ToolDots workspace={ws} />
+                        </div>
+                        <p
+                          className="truncate text-[10px] text-muted-foreground"
+                          title={ws.path}
+                        >
+                          {ws.path.replace(/^\/Users\/[^/]+/, "~")}
+                        </p>
+                      </div>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+
+            {/* Footer: browse + rescan */}
+            <div className="flex items-center justify-between border-t border-border px-3 py-1.5">
+              <button
+                onClick={handleSelectFolder}
+                className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground"
+              >
+                <FolderOpen className="h-3 w-3" />
+                Browse...
+              </button>
+              <button
+                onClick={() => rescan()}
+                disabled={isRefetching}
+                className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground"
+              >
+                <RefreshCw
+                  className={cn("h-3 w-3", isRefetching && "animate-spin")}
+                />
+                Rescan
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Navigation */}

--- a/src/components/config/RuleViewer.tsx
+++ b/src/components/config/RuleViewer.tsx
@@ -2,6 +2,7 @@ import { X, Copy, Check, FolderOpen, Crosshair } from "lucide-react";
 import { useState } from "react";
 import type { PromptFile } from "@/types";
 import { ToolBadge } from "@/components/mcps/ToolBadge";
+import { TokenBadge } from "@/components/context";
 import { Button } from "@/components/ui/button";
 
 interface RuleViewerProps {
@@ -61,6 +62,19 @@ export function RuleViewer({ rule, onClose }: RuleViewerProps) {
                   {pattern}
                 </code>
               ))}
+            </div>
+          </div>
+        )}
+
+        {/* Context window usage */}
+        {rule.tokens > 0 && (
+          <div className="border-b border-border bg-muted/30 px-4 py-2">
+            <div className="flex items-center gap-2 text-xs">
+              <span className="font-medium text-muted-foreground">Context usage:</span>
+              <TokenBadge tokens={rule.tokens} />
+              {rule.isScoped && (
+                <span className="text-muted-foreground">(conditional)</span>
+              )}
             </div>
           </div>
         )}

--- a/src/components/context/ContextBar.tsx
+++ b/src/components/context/ContextBar.tsx
@@ -1,0 +1,111 @@
+import { cn } from "@/lib/utils";
+import { formatTokens } from "@/lib/utils";
+import type { ContextSummary } from "@/lib/api/context";
+
+interface ContextBarProps {
+  summary: ContextSummary;
+}
+
+interface Segment {
+  label: string;
+  tokens: number;
+  color: string;
+  bgColor: string;
+  dotColor: string;
+}
+
+export function ContextBar({ summary }: ContextBarProps) {
+  const segments: Segment[] = [
+    {
+      label: "Rules",
+      tokens: summary.rulesTokens,
+      color: "bg-amber-500",
+      bgColor: "bg-amber-500/80",
+      dotColor: "bg-amber-500",
+    },
+    {
+      label: "Skills (idle)",
+      tokens: summary.skillsIdleTokens,
+      color: "bg-purple-500",
+      bgColor: "bg-purple-500/80",
+      dotColor: "bg-purple-500",
+    },
+  ];
+
+  if (summary.mcpsIdleTokens !== null) {
+    segments.push({
+      label: "MCPs",
+      tokens: summary.mcpsIdleTokens,
+      color: "bg-cyan-500",
+      bgColor: "bg-cyan-500/80",
+      dotColor: "bg-cyan-500",
+    });
+  }
+
+  if (summary.rulesConditionalTokens > 0) {
+    segments.push({
+      label: "Rules (conditional)",
+      tokens: summary.rulesConditionalTokens,
+      color: "bg-amber-500/40",
+      bgColor: "bg-amber-500/30",
+      dotColor: "bg-amber-500/40",
+    });
+  }
+
+  const totalUsed = segments.reduce((acc, s) => acc + s.tokens, 0);
+  const freeTokens = Math.max(0, summary.contextLimit - totalUsed);
+
+  return (
+    <div>
+      {/* Bar */}
+      <div className="flex h-8 w-full overflow-hidden rounded-lg border border-border bg-muted/30">
+        {segments.map(
+          (segment) =>
+            segment.tokens > 0 && (
+              <div
+                key={segment.label}
+                className={cn(
+                  "relative flex items-center justify-center transition-all",
+                  segment.bgColor
+                )}
+                style={{
+                  width: `${Math.max((segment.tokens / summary.contextLimit) * 100, 0.5)}%`,
+                }}
+                title={`${segment.label}: ${segment.tokens.toLocaleString()} tokens (${((segment.tokens / summary.contextLimit) * 100).toFixed(1)}%)`}
+              >
+                {segment.tokens / summary.contextLimit > 0.05 && (
+                  <span className="truncate px-1 text-[10px] font-medium text-white">
+                    {formatTokens(segment.tokens)}
+                  </span>
+                )}
+              </div>
+            )
+        )}
+        {/* Free space */}
+        <div
+          className="flex flex-1 items-center justify-center"
+          title={`Free: ${freeTokens.toLocaleString()} tokens`}
+        />
+      </div>
+
+      {/* Legend */}
+      <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        {segments.map(
+          (segment) =>
+            segment.tokens > 0 && (
+              <div key={segment.label} className="flex items-center gap-1.5">
+                <div className={cn("h-2.5 w-2.5 rounded-full", segment.dotColor)} />
+                <span>
+                  {segment.label}: {formatTokens(segment.tokens)}
+                </span>
+              </div>
+            )
+        )}
+        <div className="flex items-center gap-1.5">
+          <div className="h-2.5 w-2.5 rounded-full bg-muted-foreground/20" />
+          <span>Free: {formatTokens(freeTokens)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/context/ContextTable.tsx
+++ b/src/components/context/ContextTable.tsx
@@ -1,0 +1,248 @@
+import { useState, useMemo } from "react";
+import { ChevronDown, ChevronUp, Crosshair } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatTokens } from "@/lib/utils";
+import type { PromptFile, SkillItem, MCPItem, MCPToolsResult, SourceTool } from "@/types";
+
+interface ContextTableProps {
+  prompts: PromptFile[];
+  skills: SkillItem[];
+  mcps: MCPItem[];
+  mcpTools: Map<string, MCPToolsResult>;
+  activeTool: SourceTool | null;
+}
+
+interface ContextRow {
+  name: string;
+  type: "rule" | "skill" | "mcp";
+  sourceTool: SourceTool;
+  scope: string;
+  idleTokens: number;
+  activeTokens: number | null;
+  isConditional: boolean;
+  isShadowed: boolean;
+}
+
+type SortField = "name" | "type" | "idleTokens" | "activeTokens";
+type SortDir = "asc" | "desc";
+
+/** Normalize scope labels: "global" → "user" for consistent display */
+function normalizeScope(scope: string): string {
+  if (scope === "global") return "user";
+  return scope;
+}
+
+export function ContextTable({ prompts, skills, mcps, mcpTools, activeTool }: ContextTableProps) {
+  const [sortField, setSortField] = useState<SortField>("idleTokens");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const rows = useMemo(() => {
+    const result: ContextRow[] = [];
+
+    // Rules
+    for (const p of prompts) {
+      if (!p.exists) continue;
+      if (activeTool && p.sourceTool !== activeTool) continue;
+      result.push({
+        name: p.name,
+        type: "rule",
+        sourceTool: p.sourceTool,
+        scope: normalizeScope(p.scope),
+        idleTokens: p.tokens,
+        activeTokens: null,
+        isConditional: p.isScoped,
+        isShadowed: false,
+      });
+    }
+
+    // Skills
+    for (const s of skills) {
+      if (activeTool && s.sourceTool !== activeTool) continue;
+      result.push({
+        name: s.name,
+        type: "skill",
+        sourceTool: s.sourceTool,
+        scope: normalizeScope(s.scope),
+        idleTokens: s.idleTokens,
+        activeTokens: s.activeTokens,
+        isConditional: false,
+        isShadowed: s.isShadowed,
+      });
+    }
+
+    // MCPs (from fetched tool definitions)
+    for (const mcp of mcps) {
+      if (activeTool && !mcp.configuredIn.includes(activeTool)) continue;
+      const tools = mcpTools.get(mcp.name);
+      if (!tools) continue;
+      result.push({
+        name: mcp.name,
+        type: "mcp",
+        sourceTool: mcp.configuredIn[0],
+        scope: normalizeScope(mcp.scope),
+        idleTokens: tools.idleTokens,
+        activeTokens: null,
+        isConditional: false,
+        isShadowed: false,
+      });
+    }
+
+    return result;
+  }, [prompts, skills, mcps, mcpTools, activeTool]);
+
+  const sortedRows = useMemo(() => {
+    return [...rows].sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case "name":
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case "type":
+          cmp = a.type.localeCompare(b.type);
+          break;
+        case "idleTokens":
+          cmp = a.idleTokens - b.idleTokens;
+          break;
+        case "activeTokens":
+          cmp = (a.activeTokens ?? 0) - (b.activeTokens ?? 0);
+          break;
+      }
+      return sortDir === "desc" ? -cmp : cmp;
+    });
+  }, [rows, sortField, sortDir]);
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(sortDir === "desc" ? "asc" : "desc");
+    } else {
+      setSortField(field);
+      setSortDir("desc");
+    }
+  };
+
+  const SortIcon = ({ field }: { field: SortField }) => {
+    if (sortField !== field) return null;
+    return sortDir === "desc" ? (
+      <ChevronDown className="h-3 w-3" />
+    ) : (
+      <ChevronUp className="h-3 w-3" />
+    );
+  };
+
+  const typeLabel = (type: string) => {
+    switch (type) {
+      case "rule":
+        return "Rule";
+      case "skill":
+        return "Skill";
+      case "mcp":
+        return "MCP";
+      default:
+        return type;
+    }
+  };
+
+  const typeColor = (type: string) => {
+    switch (type) {
+      case "rule":
+        return "text-amber-500";
+      case "skill":
+        return "text-purple-500";
+      case "mcp":
+        return "text-cyan-500";
+      default:
+        return "text-muted-foreground";
+    }
+  };
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+        No items found for the selected tool.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border bg-muted/50">
+            <th className="px-4 py-2 text-left">
+              <button
+                className="flex items-center gap-1 font-medium text-muted-foreground hover:text-foreground"
+                onClick={() => handleSort("name")}
+              >
+                Name <SortIcon field="name" />
+              </button>
+            </th>
+            <th className="px-4 py-2 text-left">
+              <button
+                className="flex items-center gap-1 font-medium text-muted-foreground hover:text-foreground"
+                onClick={() => handleSort("type")}
+              >
+                Type <SortIcon field="type" />
+              </button>
+            </th>
+            <th className="px-4 py-2 text-left font-medium text-muted-foreground">
+              Scope
+            </th>
+            <th className="px-4 py-2 text-right">
+              <button
+                className="flex items-center gap-1 font-medium text-muted-foreground hover:text-foreground ml-auto"
+                onClick={() => handleSort("idleTokens")}
+              >
+                Idle Tokens <SortIcon field="idleTokens" />
+              </button>
+            </th>
+            <th className="px-4 py-2 text-right">
+              <button
+                className="flex items-center gap-1 font-medium text-muted-foreground hover:text-foreground ml-auto"
+                onClick={() => handleSort("activeTokens")}
+              >
+                Active Tokens <SortIcon field="activeTokens" />
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sortedRows.map((row, i) => (
+            <tr
+              key={`${row.type}-${row.name}-${i}`}
+              className={cn(
+                "border-b border-border last:border-b-0",
+                row.isShadowed && "opacity-50"
+              )}
+            >
+              <td className="px-4 py-2 font-mono text-xs">
+                <div className="flex items-center gap-1.5">
+                  {row.name}
+                  {row.isConditional && (
+                    <span title="Conditionally loaded">
+                      <Crosshair className="h-3 w-3 text-teal-500" />
+                    </span>
+                  )}
+                  {row.isShadowed && (
+                    <span className="text-[10px] text-muted-foreground">(shadowed)</span>
+                  )}
+                </div>
+              </td>
+              <td className={cn("px-4 py-2 text-xs font-medium", typeColor(row.type))}>
+                {typeLabel(row.type)}
+              </td>
+              <td className="px-4 py-2 text-xs text-muted-foreground">
+                {row.scope}
+              </td>
+              <td className="px-4 py-2 text-right text-xs tabular-nums">
+                {formatTokens(row.idleTokens)}
+              </td>
+              <td className="px-4 py-2 text-right text-xs tabular-nums text-muted-foreground">
+                {row.activeTokens !== null ? formatTokens(row.activeTokens) : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/context/TokenBadge.tsx
+++ b/src/components/context/TokenBadge.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+import { formatTokens } from "@/lib/utils";
+
+interface TokenBadgeProps {
+  tokens: number;
+  label?: string;
+  className?: string;
+}
+
+function getTokenColor(tokens: number): string {
+  if (tokens < 1000) return "bg-green-500/10 text-green-600 border-green-500/20";
+  if (tokens < 5000) return "bg-yellow-500/10 text-yellow-600 border-yellow-500/20";
+  return "bg-orange-500/10 text-orange-600 border-orange-500/20";
+}
+
+export function TokenBadge({ tokens, label, className }: TokenBadgeProps) {
+  if (tokens === 0) return null;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium",
+        getTokenColor(tokens),
+        className
+      )}
+      title={`${tokens.toLocaleString()} estimated tokens`}
+    >
+      {label && <span className="text-muted-foreground">{label}</span>}
+      {formatTokens(tokens)} tokens
+    </span>
+  );
+}

--- a/src/components/context/index.ts
+++ b/src/components/context/index.ts
@@ -1,0 +1,3 @@
+export { TokenBadge } from "./TokenBadge";
+export { ContextBar } from "./ContextBar";
+export { ContextTable } from "./ContextTable";

--- a/src/components/skills/SkillViewer.tsx
+++ b/src/components/skills/SkillViewer.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import type { SkillItem, SourceTool } from "@/types";
 import { installSkillToTools } from "@/lib/api/sync";
 import { ToolBadge } from "@/components/mcps/ToolBadge";
+import { TokenBadge } from "@/components/context";
 import { SyncDialog } from "@/components/sync";
 import { MaturityBadge } from "./MaturityBadge";
 import { Button } from "@/components/ui/button";
@@ -51,6 +52,15 @@ export function SkillViewer({ skill, onClose }: SkillViewerProps) {
         {/* Description */}
         <div className="border-b border-border bg-muted/30 px-4 py-2">
           <p className="text-sm text-muted-foreground">{skill.description}</p>
+        </div>
+
+        {/* Context window usage */}
+        <div className="border-b border-border bg-muted/30 px-4 py-2">
+          <div className="flex items-center gap-2 text-xs">
+            <span className="font-medium text-muted-foreground">Context usage:</span>
+            <TokenBadge tokens={skill.idleTokens} label="idle" />
+            <TokenBadge tokens={skill.activeTokens} label="invoked" />
+          </div>
         </div>
 
         {/* Content */}

--- a/src/lib/api/context.ts
+++ b/src/lib/api/context.ts
@@ -1,0 +1,84 @@
+import type { PromptFile, SkillItem, MCPItem, MCPToolsResult, SourceTool } from "@/types";
+
+/** Default context window size for Claude models */
+export const CONTEXT_WINDOW_LIMIT = 200_000;
+
+export interface ContextSummary {
+  /** Total tokens consumed at idle (rules + skills idle + MCPs if fetched) */
+  totalIdleTokens: number;
+  /** Total tokens if all skills are invoked */
+  totalActiveTokens: number;
+  /** Context window limit */
+  contextLimit: number;
+  /** Breakdown by category */
+  rulesTokens: number;
+  rulesConditionalTokens: number;
+  skillsIdleTokens: number;
+  skillsActiveTokens: number;
+  mcpsIdleTokens: number | null;
+}
+
+/**
+ * Aggregate token usage from existing scan results (client-side computation).
+ * When activeTool is set, only items for that tool are included.
+ */
+export function computeContextSummary(
+  prompts: PromptFile[],
+  skills: SkillItem[],
+  mcps: MCPItem[],
+  mcpToolsMap: Map<string, MCPToolsResult>,
+  mcpToolsFetched: boolean,
+  activeTool: SourceTool | null
+): ContextSummary {
+  // Rules: sum tokens, separate always-loaded from conditional
+  let rulesTokens = 0;
+  let rulesConditionalTokens = 0;
+  for (const p of prompts) {
+    if (!p.exists) continue;
+    if (activeTool && p.sourceTool !== activeTool) continue;
+    if (p.isScoped) {
+      rulesConditionalTokens += p.tokens;
+    } else {
+      rulesTokens += p.tokens;
+    }
+  }
+
+  // Skills: sum idle (name+desc) and active (full content)
+  let skillsIdleTokens = 0;
+  let skillsActiveTokens = 0;
+  for (const s of skills) {
+    if (s.isShadowed) continue;
+    if (activeTool && s.sourceTool !== activeTool) continue;
+    skillsIdleTokens += s.idleTokens;
+    skillsActiveTokens += s.activeTokens;
+  }
+
+  // MCPs: sum from fetched tool definitions
+  let mcpsIdleTokens: number | null = null;
+  if (mcpToolsFetched) {
+    mcpsIdleTokens = 0;
+    for (const mcp of mcps) {
+      if (activeTool && !mcp.configuredIn.includes(activeTool)) continue;
+      const tools = mcpToolsMap.get(mcp.name);
+      if (tools) {
+        mcpsIdleTokens += tools.idleTokens;
+      }
+    }
+  }
+
+  const totalIdleTokens =
+    rulesTokens + skillsIdleTokens + (mcpsIdleTokens ?? 0);
+  const totalActiveTokens =
+    rulesTokens + skillsActiveTokens + (mcpsIdleTokens ?? 0);
+
+  return {
+    totalIdleTokens,
+    totalActiveTokens,
+    contextLimit: CONTEXT_WINDOW_LIMIT,
+    rulesTokens,
+    rulesConditionalTokens,
+    skillsIdleTokens,
+    skillsActiveTokens,
+    mcpsIdleTokens,
+  };
+}

--- a/src/lib/api/mcps.ts
+++ b/src/lib/api/mcps.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { MCPItem, HealthTestResult } from "@/types";
+import type { MCPItem, HealthTestResult, MCPToolsResult } from "@/types";
 
 /**
  * Scan all MCP configurations from Claude Code, Codex CLI, and Gemini CLI
@@ -23,5 +23,25 @@ export async function testMCPHealth(mcp: MCPItem): Promise<HealthTestResult> {
     args: mcp.args,
     url: mcp.url,
     configPath: mcp.path,
+  });
+}
+
+/**
+ * Fetch tool definitions from an MCP server via tools/list JSON-RPC.
+ * Connects to the MCP, performs initialize + tools/list, then estimates token usage.
+ *
+ * @param useKeychain - When true, attempts to read OAuth tokens from macOS Keychain.
+ *   When false (default), HTTP MCPs that need OAuth will return an auth error
+ *   so the UI can show a consent prompt before requesting Keychain access.
+ */
+export async function fetchMCPTools(mcp: MCPItem, useKeychain = false): Promise<MCPToolsResult> {
+  return invoke<MCPToolsResult>("fetch_mcp_tools", {
+    name: mcp.name,
+    mcpType: mcp.mcpType,
+    command: mcp.command,
+    args: mcp.args,
+    url: mcp.url,
+    configPath: mcp.path,
+    useKeychain,
   });
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Format a token count for display.
+ * e.g., 340 → "~340", 2100 → "~2.1K", 15000 → "~15K"
+ */
+export function formatTokens(n: number): string {
+  if (n < 1000) return `~${n}`;
+  if (n < 10000) return `~${(n / 1000).toFixed(1)}K`;
+  return `~${Math.round(n / 1000)}K`;
+}

--- a/src/pages/Context.tsx
+++ b/src/pages/Context.tsx
@@ -1,0 +1,444 @@
+import { useState, useMemo } from "react";
+import { RefreshCw, AlertCircle, FolderOpen, Zap, HelpCircle, KeyRound } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { cn } from "@/lib/utils";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { scanRules } from "@/lib/api/config";
+import { scanMCPs, fetchMCPTools } from "@/lib/api/mcps";
+import { scanSkills } from "@/lib/api/skills";
+import { computeContextSummary } from "@/lib/api/context";
+import { formatTokens } from "@/lib/utils";
+import { ContextBar } from "@/components/context/ContextBar";
+import { ContextTable } from "@/components/context/ContextTable";
+import { Button } from "@/components/ui/button";
+import type { MCPItem, MCPToolsResult, SourceTool } from "@/types";
+
+const TOOL_FILTERS: { label: string; value: SourceTool }[] = [
+  { label: "Claude", value: "claude" },
+  { label: "Codex", value: "codex" },
+  { label: "Gemini", value: "gemini" },
+];
+
+export function Context() {
+  const { current } = useWorkspaceStore();
+  const workspacePath = current?.repo_root ?? current?.path ?? undefined;
+
+  const [activeTool, setActiveTool] = useState<SourceTool>("claude");
+  const [showHelp, setShowHelp] = useState(false);
+
+  // Fetch rules
+  const {
+    data: rulesResult,
+    isLoading: rulesLoading,
+    error: rulesError,
+  } = useQuery({
+    queryKey: ["rules", workspacePath ?? null],
+    queryFn: () => scanRules(workspacePath),
+  });
+
+  // Fetch skills
+  const {
+    data: skillsResult,
+    isLoading: skillsLoading,
+    error: skillsError,
+  } = useQuery({
+    queryKey: ["skills", workspacePath ?? null],
+    queryFn: () => scanSkills(workspacePath),
+  });
+
+  // Fetch MCPs
+  const {
+    data: mcps,
+  } = useQuery({
+    queryKey: ["mcps", workspacePath ?? null],
+    queryFn: () => scanMCPs(workspacePath),
+  });
+
+  // MCP tool definitions (fetched on-demand)
+  const [mcpToolsMap, setMcpToolsMap] = useState<Map<string, MCPToolsResult>>(new Map());
+  const [fetchingMCPTools, setFetchingMCPTools] = useState(false);
+  const [mcpToolsFetched, setMcpToolsFetched] = useState(false);
+  const [mcpFetchErrors, setMcpFetchErrors] = useState<Map<string, string>>(new Map());
+  // MCPs that need Keychain access (auth errors from phase 1)
+  const [mcpsNeedingKeychain, setMcpsNeedingKeychain] = useState<Set<string>>(new Set());
+  const [fetchingKeychain, setFetchingKeychain] = useState<Set<string>>(new Set());
+
+  /** Phase 1: Fetch all MCPs WITHOUT Keychain access */
+  const handleFetchMCPTools = async () => {
+    if (!mcps || mcps.length === 0) return;
+    setFetchingMCPTools(true);
+    setMcpFetchErrors(new Map());
+    setMcpsNeedingKeychain(new Set());
+
+    const newMap = new Map<string, MCPToolsResult>();
+    const newErrors = new Map<string, string>();
+    const needsKeychain = new Set<string>();
+
+    await Promise.all(
+      mcps.map(async (mcp: MCPItem) => {
+        try {
+          const result = await fetchMCPTools(mcp, false);
+          newMap.set(mcp.name, result);
+        } catch (e) {
+          const errMsg = e instanceof Error ? e.message : String(e);
+          // Detect auth errors on HTTP MCPs — these could be resolved with Keychain
+          if (mcp.mcpType === "http" && /authentication required|authentication failed/i.test(errMsg)) {
+            needsKeychain.add(mcp.name);
+          } else {
+            newErrors.set(mcp.name, errMsg);
+          }
+        }
+      })
+    );
+
+    setMcpToolsMap(newMap);
+    setMcpFetchErrors(newErrors);
+    setMcpsNeedingKeychain(needsKeychain);
+    setMcpToolsFetched(true);
+    setFetchingMCPTools(false);
+  };
+
+  /** Phase 2: Re-fetch a specific MCP WITH Keychain access (user-consented) */
+  const handleGrantKeychainAccess = async (mcpName: string) => {
+    const mcp = mcps?.find((m) => m.name === mcpName);
+    if (!mcp) return;
+
+    setFetchingKeychain((prev) => new Set(prev).add(mcpName));
+
+    try {
+      const result = await fetchMCPTools(mcp, true);
+      setMcpToolsMap((prev) => {
+        const next = new Map(prev);
+        next.set(mcpName, result);
+        return next;
+      });
+      setMcpsNeedingKeychain((prev) => {
+        const next = new Set(prev);
+        next.delete(mcpName);
+        return next;
+      });
+      // Clear any previous error for this MCP
+      setMcpFetchErrors((prev) => {
+        const next = new Map(prev);
+        next.delete(mcpName);
+        return next;
+      });
+    } catch (e) {
+      const errMsg = e instanceof Error ? e.message : String(e);
+      setMcpFetchErrors((prev) => {
+        const next = new Map(prev);
+        next.set(mcpName, errMsg);
+        return next;
+      });
+      setMcpsNeedingKeychain((prev) => {
+        const next = new Set(prev);
+        next.delete(mcpName);
+        return next;
+      });
+    } finally {
+      setFetchingKeychain((prev) => {
+        const next = new Set(prev);
+        next.delete(mcpName);
+        return next;
+      });
+    }
+  };
+
+  const prompts = rulesResult?.prompts ?? [];
+  const skills = skillsResult?.skills ?? [];
+  const mcpsList = mcps ?? [];
+
+  // Filter MCPs by active tool
+  const filteredMcps = useMemo(() => {
+    return mcpsList.filter((mcp) => mcp.configuredIn.includes(activeTool));
+  }, [mcpsList, activeTool]);
+
+  const summary = useMemo(() => {
+    return computeContextSummary(
+      prompts,
+      skills,
+      mcpsList,
+      mcpToolsMap,
+      mcpToolsFetched,
+      activeTool
+    );
+  }, [prompts, skills, mcpsList, mcpToolsMap, mcpToolsFetched, activeTool]);
+
+  const isLoading = rulesLoading || skillsLoading;
+  const error = rulesError || skillsError;
+
+  const idlePercent = ((summary.totalIdleTokens / summary.contextLimit) * 100).toFixed(1);
+
+  return (
+    <div className="p-6">
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">Context Window</h2>
+          <p className="mt-1 text-muted-foreground">
+            Estimated token usage across rules, skills, and MCPs
+          </p>
+        </div>
+
+        {/* Tool filter */}
+        <div className="flex items-center gap-1 rounded-lg border border-border bg-muted/50 p-1">
+          {TOOL_FILTERS.map((filter) => (
+            <button
+              key={filter.label}
+              onClick={() => setActiveTool(filter.value)}
+              className={cn(
+                "rounded-md px-3 py-1 text-xs font-medium transition-colors",
+                activeTool === filter.value
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {!current && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+          <FolderOpen className="h-4 w-4 shrink-0" />
+          <span>
+            Showing global config only. Select a workspace to include
+            project-level rules and skills.
+          </span>
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <RefreshCw className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/5 p-4">
+          <div className="flex items-center gap-2 text-red-600">
+            <AlertCircle className="h-5 w-5" />
+            <span className="font-medium">Failed to scan configurations</span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : "Unknown error occurred"}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !error && (
+        <div className="space-y-6">
+          {/* Summary text */}
+          <div className="rounded-lg border border-border bg-card p-4">
+            <p className="text-sm">
+              <span className="font-medium capitalize">{activeTool}</span>{" "}
+              configuration consumes an estimated{" "}
+              <span className="font-semibold">
+                {formatTokens(summary.totalIdleTokens)}
+              </span>{" "}
+              tokens at idle (
+              <span className="font-medium">{idlePercent}%</span> of 200K).
+              {activeTool === "claude" && summary.mcpsIdleTokens !== null && summary.mcpsIdleTokens > 0 && (
+                <span className="text-muted-foreground">
+                  {" "}Claude Code's Tool Search may load fewer MCP tools per turn.
+                </span>
+              )}
+              {summary.rulesConditionalTokens > 0 && (
+                <>
+                  {" "}Conditional rules add up to{" "}
+                  <span className="font-semibold">
+                    {formatTokens(summary.rulesConditionalTokens)}
+                  </span>{" "}
+                  more when active.
+                </>
+              )}
+            </p>
+          </div>
+
+          {/* More about context window */}
+          <button
+            onClick={() => setShowHelp(!showHelp)}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <HelpCircle className="h-3.5 w-3.5" />
+            {showHelp ? "Hide details" : "More about context window"}
+          </button>
+
+          {showHelp && (
+            <div className="rounded-lg border border-border bg-card p-4">
+              <p className="mb-2 text-xs font-medium">
+                How context loading works
+              </p>
+              <div className="space-y-2 text-xs text-muted-foreground">
+                <div>
+                  <span className="font-medium text-amber-500">Rules</span>{" "}
+                  — Full content loaded on every message. Always-on cost.
+                </div>
+                <div>
+                  <span className="font-medium text-purple-500">Skills</span>{" "}
+                  — Only name + description loaded idle. Full content loaded when invoked.
+                </div>
+                <div>
+                  <span className="font-medium text-cyan-500">MCPs</span>{" "}
+                  — Full tool definitions (name, description, JSON schema) loaded on every message.
+                  {activeTool === "claude" && (
+                    <span className="text-muted-foreground/70">
+                      {" "}Claude Code's Tool Search can dynamically load only relevant tools per turn,
+                      so actual usage may be lower than shown.
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              <p className="mb-2 mt-4 text-xs font-medium">
+                Idle vs Active tokens
+              </p>
+              <div className="space-y-2 text-xs text-muted-foreground">
+                <div>
+                  <span className="font-medium text-foreground">Idle tokens</span>{" "}
+                  — Consumed on every single message you send, even when the item is not being used.
+                  Rules and MCP tool definitions are always idle cost.
+                </div>
+                <div>
+                  <span className="font-medium text-foreground">Active tokens</span>{" "}
+                  — Only consumed when you invoke the item. Skills are the only type with a
+                  different active cost — their full content loads only when your or the model invokes the skill.
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Stacked bar */}
+          <ContextBar summary={summary} />
+
+          {/* MCP tools section */}
+          {filteredMcps.length > 0 && (
+            <div className="rounded-lg border border-border bg-card p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-sm font-medium">MCP Tool Definitions</h3>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {mcpToolsFetched
+                      ? `Fetched tool definitions from ${filteredMcps.filter((m) => mcpToolsMap.has(m.name)).length} of ${filteredMcps.length} MCPs`
+                      : `${filteredMcps.length} MCP server${filteredMcps.length === 1 ? "" : "s"} found. Fetch tool definitions to see their context impact.`}
+                  </p>
+                </div>
+                {!mcpToolsFetched && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleFetchMCPTools}
+                    disabled={fetchingMCPTools}
+                  >
+                    {fetchingMCPTools ? (
+                      <RefreshCw className="mr-2 h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Zap className="mr-2 h-3.5 w-3.5" />
+                    )}
+                    {fetchingMCPTools ? "Fetching..." : "Fetch Tool Definitions"}
+                  </Button>
+                )}
+                {mcpToolsFetched && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleFetchMCPTools}
+                    disabled={fetchingMCPTools}
+                  >
+                    <RefreshCw
+                      className={`mr-2 h-3.5 w-3.5 ${fetchingMCPTools ? "animate-spin" : ""}`}
+                    />
+                    Refetch
+                  </Button>
+                )}
+              </div>
+
+              {/* Show per-MCP results */}
+              {mcpToolsFetched && (
+                <div className="mt-3 space-y-1">
+                  {filteredMcps.map((mcp) => {
+                    const tools = mcpToolsMap.get(mcp.name);
+                    const fetchError = mcpFetchErrors.get(mcp.name);
+                    const needsKeychain = mcpsNeedingKeychain.has(mcp.name);
+                    const isFetchingKeychain = fetchingKeychain.has(mcp.name);
+
+                    if (needsKeychain) {
+                      return (
+                        <div
+                          key={mcp.name}
+                          className="rounded-md border border-amber-500/20 bg-amber-500/5 px-3 py-2"
+                        >
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-2">
+                              <KeyRound className="h-3.5 w-3.5 text-amber-500" />
+                              <span className="font-mono text-xs">{mcp.name}</span>
+                            </div>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-6 text-[11px]"
+                              onClick={() => handleGrantKeychainAccess(mcp.name)}
+                              disabled={isFetchingKeychain}
+                            >
+                              {isFetchingKeychain ? (
+                                <RefreshCw className="mr-1.5 h-3 w-3 animate-spin" />
+                              ) : (
+                                <KeyRound className="mr-1.5 h-3 w-3" />
+                              )}
+                              {isFetchingKeychain ? "Accessing..." : "Grant Keychain Access"}
+                            </Button>
+                          </div>
+                          <p className="mt-1 text-[11px] text-muted-foreground">
+                            This MCP requires authentication to list its tools and estimate token usage.
+                            Loadout reads the OAuth token from your macOS Keychain — everything stays local, nothing is stored or transmitted.
+                          </p>
+                        </div>
+                      );
+                    }
+                    if (fetchError) {
+                      return (
+                        <div
+                          key={mcp.name}
+                          className="flex items-center justify-between rounded px-2 py-1 text-xs"
+                        >
+                          <span className="font-mono">{mcp.name}</span>
+                          <span className="text-red-500">{fetchError}</span>
+                        </div>
+                      );
+                    }
+                    if (tools) {
+                      return (
+                        <div
+                          key={mcp.name}
+                          className="flex items-center justify-between rounded px-2 py-1 text-xs hover:bg-muted/50"
+                        >
+                          <span className="font-mono">{mcp.name}</span>
+                          <span className="text-muted-foreground">
+                            {tools.toolCount} tool{tools.toolCount === 1 ? "" : "s"} · {formatTokens(tools.idleTokens)}
+                          </span>
+                        </div>
+                      );
+                    }
+                    return null;
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Items table */}
+          <div>
+            <h3 className="mb-2 text-sm font-medium">All Items</h3>
+            <ContextTable
+              prompts={prompts}
+              skills={skills}
+              mcps={mcpsList}
+              mcpTools={mcpToolsMap}
+              activeTool={activeTool}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -5,10 +5,10 @@ import type { WorkspaceInfo } from "@/lib/api/workspace";
 interface WorkspaceState {
   current: WorkspaceInfo | null;
   recent: string[];
-  activeTab: "mcps" | "skills" | "rules" | "hooks";
+  activeTab: "mcps" | "skills" | "rules" | "hooks" | "context";
   setCurrent: (workspace: WorkspaceInfo | null) => void;
   addRecent: (path: string) => void;
-  setActiveTab: (tab: "mcps" | "skills" | "rules" | "hooks") => void;
+  setActiveTab: (tab: "mcps" | "skills" | "rules" | "hooks" | "context") => void;
 }
 
 const MAX_RECENT = 5;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -92,6 +92,8 @@ export interface MCPItem {
   url: string | null;
   /** Environment variables (values masked) */
   env: Record<string, string>;
+  /** HTTP headers (for http type, values masked) */
+  headers: Record<string, string>;
   /** Which tools this MCP is configured in */
   configuredIn: SourceTool[];
   /** Scope (user or project level) */
@@ -128,6 +130,10 @@ export interface SkillItem {
   maturity: Maturity;
   /** Absolute path to the SKILL.md file */
   path: string;
+  /** Estimated tokens when idle (just name + description in skill listing) */
+  idleTokens: number;
+  /** Estimated tokens when actively invoked (full content) */
+  activeTokens: number;
   /** True if this skill is shadowed by a higher-precedence skill */
   isShadowed: boolean;
   /** Path of the skill that shadows this one */
@@ -179,6 +185,8 @@ export interface PromptFile {
   exists: boolean;
   content: string;
   size: number;
+  /** Estimated token count for context window usage */
+  tokens: number;
   /** Glob patterns that scope this rule. Undefined = always loaded. */
   scopedPaths?: string[];
   /** Whether this rule is conditionally scoped (true) or always loaded (false). */
@@ -302,4 +310,26 @@ export interface PreviewConfig {
  */
 export interface PreviewResult {
   configs: PreviewConfig[];
+}
+
+// === Context Window / Token Types ===
+
+/**
+ * Information about a single MCP tool definition
+ */
+export interface MCPToolInfo {
+  name: string;
+  description: string | null;
+  /** Estimated tokens for this tool's definition */
+  tokens: number;
+}
+
+/**
+ * Result of fetching MCP tool definitions via tools/list
+ */
+export interface MCPToolsResult {
+  toolCount: number;
+  /** Total estimated idle tokens (all tool definitions) */
+  idleTokens: number;
+  tools: MCPToolInfo[];
 }


### PR DESCRIPTION
## Summary
Add a dedicated Context Window page showing estimated token usage across rules, skills, and MCPs. Users can switch between Claude Code, Codex, and Gemini to see tool-specific context consumption. MCP tool definitions can be fetched to estimate token impact, with Keychain support for authenticated servers.

## Key Features
- Visual breakdown of token usage by category with ContextBar and detailed ContextTable
- MCP tool fetching with per-tool token estimation and OAuth Keychain integration
- Tool-specific filtering to compare context impact across Claude, Codex, and Gemini
- Helpful notes about Claude Code's dynamic Tool Search reducing actual context usage
- Clear privacy messaging for Keychain access flows

## Testing
- Verify Context page loads with all rules and skills detected
- Test MCP tool fetching with both stdio and HTTP servers
- Check Keychain access flow for authenticated MCPs (macOS)
- Confirm filter switching correctly updates token estimates