### PR TITLE
refactor: Align rules scope terminology with documentation

### DIFF
--- a/src-tauri/src/scanners/prompts.rs
+++ b/src-tauri/src/scanners/prompts.rs
@@ -23,7 +23,7 @@ pub enum PromptSourceTool {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum PromptScope {
-    Global,
+    User,
     Project,
 }
 
@@ -76,7 +76,7 @@ pub fn scan_all_prompts(workspace_path: Option<&str>) -> Result<PromptScanResult
 
     for (tool, path) in global_paths {
         let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
-        prompts.push(scan_prompt_file(&name, tool, PromptScope::Global, &path));
+        prompts.push(scan_prompt_file(&name, tool, PromptScope::User, &path));
     }
 
     // === Global rules directories ===
@@ -84,7 +84,7 @@ pub fn scan_all_prompts(workspace_path: Option<&str>) -> Result<PromptScanResult
     scan_rules_directory(
         &mut prompts,
         PromptSourceTool::Claude,
-        PromptScope::Global,
+        PromptScope::User,
         &home_dir.join(".claude").join("rules"),
     );
 
@@ -406,7 +406,7 @@ mod tests {
         let mut file = fs::File::create(&path).unwrap();
         writeln!(file, "# System Prompt\nBe helpful.").unwrap();
 
-        let result = scan_prompt_file("CLAUDE.md", PromptSourceTool::Claude, PromptScope::Global, &path);
+        let result = scan_prompt_file("CLAUDE.md", PromptSourceTool::Claude, PromptScope::User, &path);
         assert!(result.exists);
         assert_eq!(result.name, "CLAUDE.md");
         assert!(result.content.contains("Be helpful"));
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn test_scan_prompt_file_missing() {
         let path = PathBuf::from("/nonexistent/CLAUDE.md");
-        let result = scan_prompt_file("CLAUDE.md", PromptSourceTool::Claude, PromptScope::Global, &path);
+        let result = scan_prompt_file("CLAUDE.md", PromptSourceTool::Claude, PromptScope::User, &path);
         assert!(!result.exists);
         assert!(result.content.is_empty());
         assert_eq!(result.size, 0);

--- a/src/components/config/PromptsSection.tsx
+++ b/src/components/config/PromptsSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FileText, Globe, FolderOpen, Crosshair } from "lucide-react";
+import { FileText, User, FolderOpen, Crosshair } from "lucide-react";
 import type { PromptFile } from "@/types";
 import { RuleCard } from "./RuleCard";
 import { RuleViewer } from "./RuleViewer";
@@ -12,7 +12,7 @@ interface PromptsSectionProps {
 export function PromptsSection({ prompts, workspaceName }: PromptsSectionProps) {
   const [selectedRule, setSelectedRule] = useState<PromptFile | null>(null);
 
-  const globalRules = prompts.filter((p) => p.scope === "global");
+  const userRules = prompts.filter((p) => p.scope === "user");
   const projectRules = prompts.filter((p) => p.scope === "project");
   const alwaysLoadedProjectRules = projectRules.filter((p) => !p.isScoped);
   const scopedProjectRules = projectRules.filter((p) => p.isScoped);
@@ -49,15 +49,15 @@ export function PromptsSection({ prompts, workspaceName }: PromptsSectionProps) 
   return (
     <>
       <div className="space-y-6">
-        {/* Global rules */}
-        {globalRules.length > 0 && (
+        {/* User rules */}
+        {userRules.length > 0 && (
           <div>
             <h4 className="mb-3 flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
-              <Globe className="h-3.5 w-3.5" />
-              Global — applies to all projects
+              <User className="h-3.5 w-3.5" />
+              User — applies to all projects
             </h4>
             <div className="space-y-2">
-              {globalRules.map((rule) => (
+              {userRules.map((rule) => (
                 <RuleCard
                   key={rule.path}
                   rule={rule}

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -45,7 +45,7 @@ export function Rules() {
         <div className="mb-4 flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
           <FolderOpen className="h-4 w-4 shrink-0" />
           <span>
-            Showing global rules only. Select a workspace to also see
+            Showing user-level rules only. Select a workspace to also see
             project-level rules.
           </span>
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -172,7 +172,7 @@ export interface HealthTestResult {
 
 // === Rules & Hooks Types ===
 
-export type PromptScope = "global" | "project";
+export type PromptScope = "user" | "project";
 
 /**
  * A discovered system prompt file


### PR DESCRIPTION
## Summary

Rename `PromptScope::Global` → `User` to match official Claude Code, Codex, and Gemini documentation. MCPs and Skills already use "user" scope for user-level configuration, making this change consistent across the app.

The three-tier model (User → Project → Scoped) is now uniformly named across all configuration types.

## Changes

- **Rust backend**: Updated `PromptScope` enum and all call sites
- **TypeScript**: Updated `PromptScope` type definition
- **UI**: Updated labels, replaced Globe icon with User icon, renamed variables

All 68 tests pass, frontend builds cleanly.