### PR TITLE
docs: Add pending issue specs (Issues 12-18)

### DIFF
--- a/issues/12-pending-test-data-fixtures.md
+++ b/issues/12-pending-test-data-fixtures.md
@@ -1,0 +1,298 @@
+# Issue 12: Test Data Fixtures for Screenshots & Demos
+
+**Phase:** 1 (Read-Only MVP)
+**Status:** Pending
+
+---
+
+## Summary
+
+Create a self-contained test data setup so we can take product screenshots, record demos, and develop the UI without touching the developer's real AI coding configuration (`~/.claude.json`, `~/.gemini/settings.json`, etc.). The test data must be editable, look realistic, exercise the full parsing/scanning pipeline, and be completely isolated from the main app logic.
+
+## Problem
+
+Today all scanners (`scan_all_mcps`, `scan_all_skills`, `scan_all_prompts`, `scan_all_hooks`, `discover_workspaces`) call `dirs::home_dir()` directly with no override. This means:
+
+- Screenshots show your actual MCP servers, skills, and rules
+- You can't craft a "perfect" dataset with diverse entries for marketing
+- Testing edge cases (many items, long names, errors) requires modifying real configs
+- Onboarding new contributors forces them to set up real AI tool configs
+
+## Approach: Fake Home Directory with `LOADOUT_HOME`
+
+Introduce a single environment variable `LOADOUT_HOME` that overrides `dirs::home_dir()` across all scanners, guarded by `#[cfg(debug_assertions)]` so it is compiled out of release builds entirely. Ship a `fixtures/` directory in the repo with realistic config files.
+
+### Why this approach
+
+- **Full stack testing**: exercises the real Rust parsers, scanners, and frontend rendering — no mocks
+- **Zero production impact**: `#[cfg(debug_assertions)]` strips the env var check from release binaries — the code literally doesn't exist in `pnpm tauri build` output
+- **Easy to use**: one env var, two npm scripts
+- **Editable by anyone**: fixtures are plain `.json`, `.toml`, `.md` files — no Rust knowledge needed
+- **Future-proof**: doubles as infrastructure for integration tests
+
+### Usage
+
+```bash
+pnpm dev            # real data — your actual ~ configs
+pnpm dev:fixtures   # test data — uses fixtures/home/ as fake ~
+```
+
+## Acceptance Criteria
+
+### Rust changes
+- [ ] Add `effective_home()` helper in `src-tauri/src/helpers.rs` (or similar) that checks `LOADOUT_HOME` behind `#[cfg(debug_assertions)]`, falls back to `dirs::home_dir()`
+- [ ] Replace all `dirs::home_dir()` calls with `effective_home()` in: `scanners/mcps.rs`, `scanners/skills.rs`, `scanners/prompts.rs`, `scanners/hooks.rs`, `scanners/workspaces.rs`, `commands/sync.rs`, `commands/mcps.rs`
+- [ ] Verify `pnpm tauri build` (release) produces identical behavior — no env var check in binary
+
+### Fixture files
+- [ ] `fixtures/home/.claude.json` — user-level MCPs for Claude (stdio + HTTP mix)
+- [ ] `fixtures/home/.claude/settings.json` — hooks + permissions
+- [ ] `fixtures/home/.claude/CLAUDE.md` — global rules
+- [ ] `fixtures/home/.claude/rules/*.md` — scoped rule files
+- [ ] `fixtures/home/.claude/skills/*/SKILL.md` — user-level skills (YAML frontmatter)
+- [ ] `fixtures/home/.claude/commands/*.md` — legacy commands (plain markdown)
+- [ ] `fixtures/home/.codex/config.toml` — user-level MCPs for Codex
+- [ ] `fixtures/home/.codex/AGENTS.md` — Codex global rules
+- [ ] `fixtures/home/.gemini/settings.json` — Gemini MCPs + hooks + experiments
+- [ ] `fixtures/home/.gemini/GEMINI.md` — Gemini global rules
+- [ ] `fixtures/workspaces/acme-app/.git/` — empty dir (repo marker)
+- [ ] `fixtures/workspaces/acme-app/.mcp.json` — project-level MCPs
+- [ ] `fixtures/workspaces/acme-app/CLAUDE.md` — project-level rules
+- [ ] `fixtures/workspaces/acme-app/.claude/skills/*/SKILL.md` — project-level skills
+
+### npm scripts
+- [ ] Add `"dev:fixtures"` script to `package.json`: `LOADOUT_HOME=./fixtures/home tauri dev`
+- [ ] Existing `"dev"` script unchanged
+
+## Technical Details
+
+### `effective_home()` implementation
+
+```rust
+use std::path::PathBuf;
+
+pub fn effective_home() -> Option<PathBuf> {
+    #[cfg(debug_assertions)]
+    if let Ok(home) = std::env::var("LOADOUT_HOME") {
+        return Some(PathBuf::from(home));
+    }
+    dirs::home_dir()
+}
+```
+
+In release builds (`pnpm tauri build`), the compiler strips the `#[cfg(debug_assertions)]` block. The function compiles to exactly `dirs::home_dir()`.
+
+### Call sites to update
+
+| File | Current call | Notes |
+|------|-------------|-------|
+| `scanners/mcps.rs` | `dirs::home_dir()` | User-level MCP scanning |
+| `scanners/skills.rs` | `dirs::home_dir()` | User-level skill scanning |
+| `scanners/prompts.rs` | `dirs::home_dir()` | Global rules scanning |
+| `scanners/hooks.rs` | `dirs::home_dir()` | Hook settings scanning |
+| `scanners/workspaces.rs` | `dirs::home_dir()` | Workspace discovery (walks from ~) |
+| `commands/sync.rs` | `dirs::home_dir()` | Config path for sync/write |
+| `commands/mcps.rs` | `dirs::home_dir()` | Keychain/env var resolution |
+
+### Fixture data contents
+
+**MCPs (9 entries across 3 tools):**
+
+| Name | Type | Tool | Scope |
+|------|------|------|-------|
+| github | stdio | Claude | user |
+| linear | http | Claude | user |
+| filesystem | stdio | Claude | user |
+| brave-search | stdio | Claude | user |
+| notion | http | Claude | user |
+| postgres | stdio | Codex | user |
+| slack | stdio | Codex | user |
+| sentry | stdio | Gemini | user |
+| supabase | stdio | Claude | project (acme-app) |
+
+**Skills (5 entries):**
+
+| Name | Format | Tool | Scope |
+|------|--------|------|-------|
+| code-review | YAML frontmatter | Claude | user |
+| test-writer | YAML frontmatter | Claude | user |
+| commit | plain markdown | Claude (legacy command) | user |
+| debug-helper | YAML frontmatter | Claude | project |
+| deploy | YAML frontmatter | Codex | user |
+
+**Rules (6 entries):**
+
+| File | Tool | Scope |
+|------|------|-------|
+| `~/.claude/CLAUDE.md` | Claude | global |
+| `~/.claude/rules/code-style.md` | Claude | global |
+| `~/.claude/rules/testing.md` | Claude | global |
+| `~/.codex/AGENTS.md` | Codex | global |
+| `~/.gemini/GEMINI.md` | Gemini | global |
+| `acme-app/CLAUDE.md` | Claude | project |
+
+**Hooks (3 entries):**
+
+| Event | Tool | Matcher |
+|-------|------|---------|
+| PreToolUse | Claude | `Bash\|Write` |
+| PostToolUse | Claude | (none — all tools) |
+| BeforeTool | Gemini | `shell` |
+
+### Concrete fixture file examples
+
+**`fixtures/home/.claude.json`**
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_TOKEN": "ghp_xxxxxxxxxxxx" }
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/sse",
+      "headers": { "x-api-key": "${LINEAR_API_KEY}" }
+    },
+    "filesystem": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/demo/projects"]
+    },
+    "brave-search": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+      "env": { "BRAVE_API_KEY": "BSA_xxxxxxxxxxxx" }
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.so/mcp"
+    }
+  }
+}
+```
+
+**`fixtures/home/.codex/config.toml`**
+```toml
+model = "o3"
+approval_policy = "on-request"
+
+[mcp_servers.postgres]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/demo"]
+
+[mcp_servers.slack]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-slack"]
+
+[mcp_servers.slack.env]
+SLACK_BOT_TOKEN = "xoxb-xxxxxxxxxxxx"
+```
+
+**`fixtures/home/.gemini/settings.json`**
+```json
+{
+  "mcpServers": {
+    "sentry": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@sentry/mcp-server"]
+    }
+  },
+  "experiments": { "enableHooks": true },
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "shell",
+        "hooks": [{ "type": "command", "command": "echo 'Tool starting'" }]
+      }
+    ]
+  }
+}
+```
+
+**`fixtures/home/.claude/settings.json`**
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Write",
+        "hooks": [{ "type": "command", "command": "echo 'Pre-tool hook'" }]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [{ "type": "command", "command": "/usr/local/bin/notify-done" }]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": ["Read", "Glob", "Grep"],
+    "deny": []
+  }
+}
+```
+
+**`fixtures/home/.claude/skills/code-review/SKILL.md`**
+```markdown
+---
+name: code-review
+description: Review code for bugs, security issues, and best practices
+metadata:
+  role: engineering
+---
+# Code Review
+
+Review the provided code for:
+1. Potential bugs and edge cases
+2. Security vulnerabilities
+3. Performance issues
+```
+
+**`fixtures/workspaces/acme-app/.mcp.json`**
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@supabase/mcp-server"],
+      "env": { "SUPABASE_URL": "https://abc.supabase.co" }
+    }
+  }
+}
+```
+
+### Project-level fixture workflow
+
+The workspace path for project-level scanning already comes as a parameter from the frontend. So to test project-level data:
+
+1. Launch with `pnpm dev:fixtures`
+2. Use the workspace picker to open `fixtures/workspaces/acme-app/`
+3. The app reads project-level `.mcp.json`, skills, and rules from that directory — no special handling needed
+
+## Test Plan
+
+1. Run `pnpm dev:fixtures` — app launches with fixture data
+2. Verify MCPs page shows 9 entries across Claude, Codex, Gemini (user-level)
+3. Select `fixtures/workspaces/acme-app` as workspace — verify `supabase` appears as project-level MCP
+4. Verify Skills page shows 5 entries with correct tool badges and scopes
+5. Verify Rules page shows 6 entries across global and project scopes
+6. Verify Hooks page shows 3 hook entries
+7. Run `pnpm dev` — verify app shows your real configs (no fixture data)
+8. Run `pnpm tauri build` — verify release binary has no `LOADOUT_HOME` behavior (set the env var and confirm it's ignored)
+
+## Dependencies
+
+- None (standalone improvement)
+
+## Notes
+
+- The `tempfile` crate is already used in existing unit tests for the same pattern — this is consistent with existing conventions
+- The workspace path for project-level scanning already comes as a parameter from the frontend, so project-level fixtures just need a `fixtures/workspaces/` directory passed via the UI
+- Fixture files use realistic but fake credentials (e.g., `ghp_xxxxxxxxxxxx`) — these are not real tokens
+- `#[cfg(debug_assertions)]` is the standard Rust mechanism for dev-only code, no custom feature flags needed

--- a/issues/13-pending-skill-icons.md
+++ b/issues/13-pending-skill-icons.md
@@ -1,0 +1,340 @@
+# Issue 13: Skill Icons — Keyword-Based Icon Matching & User Overrides
+
+**Phase:** 2 (Enhancement)
+**Status:** Pending
+
+---
+
+## Summary
+
+Replace the generic `Sparkles` icon on every skill card with a contextual icon selected by keyword-matching the skill name against a curated dictionary. This mirrors the favicon/letter-avatar approach already used for MCPs and gives each skill a distinct visual identity at a glance. Users can also override the auto-selected icon with one they prefer, persisted via Zustand + localStorage (same pattern as the workspace store).
+
+## Acceptance Criteria
+
+### Keyword-Based Icon Selection
+- [ ] Maintain a curated mapping of keywords → Lucide icon names (e.g., `commit` → `GitCommit`, `review` → `Eye`, `test` → `FlaskConical`, `deploy` → `Rocket`)
+- [ ] Match against the skill `name` field using whole-token matching only (no AI, no network calls, no substring matching)
+- [ ] Fall back to a deterministic letter-avatar (same style as stdio MCPs) when no keyword matches
+- [ ] Icon + background color are deterministic — same skill name always produces the same result
+
+### SkillIcon Component
+- [ ] New `SkillIcon` component in `src/components/skills/` (mirrors `MCPIcon` pattern)
+- [ ] Accepts `name: string` and optional `overrideIcon?: string` props
+- [ ] Renders a 40×40 rounded-lg container with icon (same dimensions as MCP icons)
+- [ ] Uses the existing `getColorForName()` hash function for consistent coloring
+- [ ] Integrates into `SkillCard` replacing the hardcoded `Sparkles` icon
+
+### User Icon Override (Optional — Can Be Deferred)
+- [ ] Clicking the icon on a skill card (or a small edit button) opens an icon picker popover
+- [ ] Icon picker shows a grid of available Lucide icons, filterable by search
+- [ ] Selected override is stored in a Zustand store with `persist` middleware (localStorage)
+- [ ] Override keyed by skill `path` (file path is stable even when the frontmatter `name` field changes — note: `id` is a hash of `name + source + scope` so it changes on rename)
+- [ ] "Reset to default" option to clear the override and revert to auto-detected icon
+- [ ] Overrides persist across app restarts
+
+## Technical Details
+
+### Keyword → Icon Dictionary
+
+A flat map of keywords to Lucide icon component names. Order matters — first match wins. Keep the list focused (30–50 entries) to avoid bloat.
+
+```typescript
+// src/components/skills/skillIconMap.ts
+
+type IconEntry = {
+  keywords: string[];
+  icon: string; // Lucide icon name
+};
+
+export const SKILL_ICON_MAP: IconEntry[] = [
+  // Version control
+  { keywords: ["commit", "git"], icon: "GitCommit" },
+  { keywords: ["branch"], icon: "GitBranch" },
+  { keywords: ["merge", "pull-request"], icon: "GitMerge" },
+
+  // Code & development
+  { keywords: ["code", "coding"], icon: "Code" },
+  { keywords: ["debug", "bug"], icon: "Bug" },
+  { keywords: ["test", "spec", "jest", "vitest"], icon: "FlaskConical" },
+  { keywords: ["build", "compile"], icon: "Hammer" },
+  { keywords: ["deploy", "ship", "release"], icon: "Rocket" },
+  { keywords: ["refactor", "clean"], icon: "Recycle" },
+  { keywords: ["lint", "format"], icon: "AlignLeft" },
+
+  // Review & analysis
+  { keywords: ["review"], icon: "Eye" },
+  { keywords: ["analyze", "analysis"], icon: "BarChart3" },
+  { keywords: ["audit", "security"], icon: "Shield" },
+  { keywords: ["search", "find", "explore"], icon: "Search" },
+
+  // Documentation
+  { keywords: ["doc", "docs", "document", "readme"], icon: "FileText" },
+  { keywords: ["write", "draft", "blog"], icon: "PenTool" },
+  { keywords: ["translate", "i18n", "locale"], icon: "Languages" },
+
+  // Data & API
+  { keywords: ["api", "endpoint", "rest", "graphql"], icon: "Plug" },
+  { keywords: ["database", "sql", "migration"], icon: "Database" },
+  { keywords: ["data", "transform", "etl"], icon: "ArrowRightLeft" },
+
+  // Infrastructure
+  { keywords: ["docker", "container"], icon: "Container" },
+  { keywords: ["monitor", "alert", "observe"], icon: "Activity" },
+  { keywords: ["config", "setting", "env"], icon: "Settings" },
+
+  // Communication
+  { keywords: ["email", "mail", "notify"], icon: "Mail" },
+  { keywords: ["chat", "message", "slack"], icon: "MessageSquare" },
+  { keywords: ["comment", "feedback"], icon: "MessageCircle" },
+
+  // AI & automation
+  { keywords: ["llm", "agent", "prompt"], icon: "Brain" },
+  { keywords: ["automate", "workflow", "pipeline"], icon: "Workflow" },
+  { keywords: ["generate", "create", "scaffold"], icon: "Wand2" },
+
+  // Planning
+  { keywords: ["plan", "design", "architect"], icon: "Compass" },
+  { keywords: ["task", "todo", "ticket"], icon: "CheckSquare" },
+  { keywords: ["schedule", "calendar", "cron"], icon: "Calendar" },
+];
+```
+
+### Matching Logic
+
+Token-only matching: split the skill name on delimiters (`-`, `_`, spaces) and match whole tokens. No `includes()` substring matching — this prevents short keywords from false-positive matching (e.g., `pr` matching `sprint`, `ai` matching `maintain`, `db` matching `sandbox`). Multi-word keywords like `pull-request` are also split into tokens and matched if all parts appear.
+
+```typescript
+// src/components/skills/skillIconMap.ts
+
+export function matchSkillIcon(name: string): string | null {
+  const tokens = new Set(name.toLowerCase().split(/[-_\s]+/));
+
+  for (const entry of SKILL_ICON_MAP) {
+    for (const keyword of entry.keywords) {
+      // Multi-word keywords (e.g., "pull-request") → all parts must be present as tokens
+      const keywordParts = keyword.split("-");
+      if (keywordParts.every((part) => tokens.has(part))) {
+        return entry.icon;
+      }
+    }
+  }
+  return null; // No match → fall back to letter avatar
+}
+```
+
+### SkillIcon Component
+
+**Important implementation notes:**
+
+1. **Tailwind class detection**: Dynamic template strings like `` `bg-${color}-500/10` `` won't be detected by Tailwind's static analysis and will be purged in production. The existing `getColorForName()` in `MCPIcon.tsx` correctly returns full static class strings (e.g., `"bg-red-500/10 text-red-500"`). `SkillIcon` must follow the same pattern.
+
+2. **Export `getColorForName`**: Currently `getColorForName` is a private function in `MCPIcon.tsx` (not exported). Phase A must either export it from `MCPIcon.tsx`, or (preferred) extract it into a shared utility at `src/lib/colors.ts` so both components import from there without cross-feature coupling.
+
+3. **Direct icon imports for Phase A**: Do NOT use `import { icons } from "lucide-react"` for Phase A — that's `import * as index` under the hood and pulls ~1500 icon components into the bundle. Instead, build a lookup map from direct imports of only the ~35 icons in the dictionary. Reserve the `icons` wildcard import for Phase B's icon picker, and lazy-load it.
+
+```typescript
+// src/lib/colors.ts — extracted from MCPIcon.tsx
+
+/**
+ * Get a consistent color class string for a given name.
+ * Returns full Tailwind class strings (e.g., "bg-red-500/10 text-red-500")
+ * so they are statically detectable by Tailwind's purge/scan.
+ */
+export function getColorForName(name: string): string {
+  const colors = [
+    "bg-red-500/10 text-red-500",
+    "bg-orange-500/10 text-orange-500",
+    // ... same 16-color palette as MCPIcon.tsx
+  ];
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash << 5) - hash + name.charCodeAt(i);
+    hash |= 0;
+  }
+  return colors[Math.abs(hash) % colors.length];
+}
+```
+
+```typescript
+// src/components/skills/skillIconMap.ts — add icon component lookup
+
+import {
+  GitCommit, GitBranch, GitMerge, Code, Bug, FlaskConical,
+  Hammer, Rocket, Recycle, AlignLeft, Eye, BarChart3, Shield,
+  Search, FileText, PenTool, Languages, Plug, Database,
+  ArrowRightLeft, Container, Activity, Settings, Mail,
+  MessageSquare, MessageCircle, Brain, Workflow, Wand2,
+  Compass, CheckSquare, Calendar,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+// Direct imports only — no wildcard `icons` import
+export const ICON_COMPONENTS: Record<string, LucideIcon> = {
+  GitCommit, GitBranch, GitMerge, Code, Bug, FlaskConical,
+  Hammer, Rocket, Recycle, AlignLeft, Eye, BarChart3, Shield,
+  Search, FileText, PenTool, Languages, Plug, Database,
+  ArrowRightLeft, Container, Activity, Settings, Mail,
+  MessageSquare, MessageCircle, Brain, Workflow, Wand2,
+  Compass, CheckSquare, Calendar,
+};
+```
+
+```typescript
+// src/components/skills/SkillIcon.tsx
+
+import { cn } from "@/lib/utils";
+import { getColorForName } from "@/lib/colors";
+import { matchSkillIcon, ICON_COMPONENTS } from "./skillIconMap";
+
+interface SkillIconProps {
+  name: string;
+  overrideIcon?: string;
+  size?: "sm" | "md";
+}
+
+export function SkillIcon({ name, overrideIcon, size = "md" }: SkillIconProps) {
+  const colorClass = getColorForName(name); // Returns "bg-red-500/10 text-red-500" etc.
+  const dims = size === "sm" ? "h-8 w-8" : "h-10 w-10";
+  const iconSize = size === "sm" ? "h-4 w-4" : "h-5 w-5";
+
+  const iconName = overrideIcon || matchSkillIcon(name);
+  const IconComponent = iconName ? ICON_COMPONENTS[iconName] : null;
+
+  if (IconComponent) {
+    // Split colorClass into bg and text parts for separate application
+    const [bgClass, textClass] = colorClass.split(" ");
+    return (
+      <div className={cn(dims, bgClass, "flex shrink-0 items-center justify-center rounded-lg")}>
+        <IconComponent className={cn(iconSize, textClass)} />
+      </div>
+    );
+  }
+
+  // Fallback: letter avatar (same pattern as stdio MCPs in MCPIcon.tsx)
+  const letter = name.charAt(0).toUpperCase();
+  return (
+    <div className={cn(
+      dims, colorClass,
+      "flex shrink-0 items-center justify-center rounded-lg font-semibold"
+    )}>
+      {letter}
+    </div>
+  );
+}
+```
+
+### Icon Override Persistence (Zustand Store)
+
+Key overrides by `path` (the file path to the SKILL.md), not `id`. The `id` field is a hash of `name + source_tool + scope` (see `generate_skill_id` in `src-tauri/src/scanners/skills.rs:247`), so renaming a skill in its frontmatter changes the `id`. The `path` remains stable as long as the file isn't moved on disk — which is the more common case for "I renamed my skill."
+
+```typescript
+// src/stores/skillIconStore.ts
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface SkillIconState {
+  overrides: Record<string, string>; // skill.path → Lucide icon name
+  setOverride: (skillPath: string, iconName: string) => void;
+  clearOverride: (skillPath: string) => void;
+}
+
+export const useSkillIconStore = create<SkillIconState>()(
+  persist(
+    (set) => ({
+      overrides: {},
+      setOverride: (skillPath, iconName) =>
+        set((state) => ({
+          overrides: { ...state.overrides, [skillPath]: iconName },
+        })),
+      clearOverride: (skillPath) =>
+        set((state) => {
+          const { [skillPath]: _, ...rest } = state.overrides;
+          return { overrides: rest };
+        }),
+    }),
+    {
+      name: "loadout-skill-icons", // localStorage key
+    }
+  )
+);
+```
+
+### Lucide Import Strategy
+
+**Phase A (keyword icons):** Use direct named imports for the ~35 icons in the dictionary (e.g., `import { GitCommit, Rocket } from "lucide-react"`). These are tree-shaken normally and add negligible bundle size.
+
+**Phase B (icon picker):** The picker needs access to all ~1500 icons by string name. Use `import { icons } from "lucide-react"` — but note this is backed by `import * as index` internally and pulls the entire icon set (~200KB gzipped). Lazy-load the `IconPicker` component via `React.lazy()` so this cost is only paid when the user actually opens the picker, not on initial page load.
+
+### Files to Create/Modify
+
+```
+src/lib/colors.ts                          # New — extract getColorForName() from MCPIcon
+src/components/mcps/MCPIcon.tsx            # Modify — import getColorForName from @/lib/colors
+src/components/skills/skillIconMap.ts      # New — keyword dictionary + matcher + ICON_COMPONENTS map
+src/components/skills/SkillIcon.tsx        # New — icon component
+src/components/skills/SkillCard.tsx        # Modify — use SkillIcon instead of Sparkles
+src/components/skills/index.ts             # Modify — export SkillIcon
+src/stores/skillIconStore.ts               # New — override persistence (Phase B only)
+src/components/skills/IconPicker.tsx        # New — lazy-loaded icon picker popover (Phase B only)
+```
+
+### Implementation Phases
+
+**Phase A (Core — do this first):**
+1. Extract `getColorForName()` from `MCPIcon.tsx` into `src/lib/colors.ts`; update `MCPIcon` to import from there
+2. Create `skillIconMap.ts` with keyword dictionary, `matchSkillIcon()`, and `ICON_COMPONENTS` (direct imports only)
+3. Create `SkillIcon` component with keyword matching + letter-avatar fallback
+4. Replace `Sparkles` in `SkillCard` with `SkillIcon`
+
+**Phase B (User Overrides — can be deferred):**
+1. Create `skillIconStore.ts` with Zustand persist
+2. Build `IconPicker` popover (grid of icons with search filter)
+3. Wire up click-to-change on the skill icon in `SkillCard`
+
+## Test Plan
+
+### Keyword Matching
+1. Skill named `commit-helper` → shows `GitCommit` icon
+2. Skill named `code-review` → shows `Eye` icon (matches `review`)
+3. Skill named `deploy-to-prod` → shows `Rocket` icon
+4. Skill named `my-custom-thing` → shows letter avatar "M" with deterministic color
+5. Two skills with the same name always show the same icon and color
+
+### No False Positives (token-only matching)
+1. Skill named `sprint-planner` → does NOT match `pr` → falls back to letter avatar or another keyword
+2. Skill named `maintain-docs` → does NOT match `ai` → matches `doc` instead
+3. Skill named `sandbox-setup` → does NOT match `db` → falls back to letter avatar
+
+### Fallback Behavior
+1. Skill with no keyword match → shows colored letter avatar (not blank)
+2. Letter avatar color is consistent across app restarts
+3. Verify the fallback visually matches the stdio MCP letter avatar style
+
+### User Override (Phase B)
+1. Click skill icon → icon picker appears
+2. Search "rocket" in picker → filters to rocket-related icons
+3. Select an icon → skill card updates immediately
+4. Restart app → override persists
+5. Click "Reset" → reverts to auto-detected icon
+6. Override for one skill does not affect others
+
+### Visual Consistency
+1. Skill cards on the Skills page show varied, colorful icons instead of uniform Sparkles
+2. Icons are legible at 40×40 size
+3. Dark mode and light mode both render correctly (using existing color system)
+
+## Dependencies
+
+- Issue 3: Skills Scanner (done — provides `SkillItem` data)
+- `lucide-react` (already installed)
+- `getColorForName()` from MCPIcon (already implemented, needs extraction to shared utility)
+
+## Notes
+
+- **No AI required**: Pure keyword token matching is fast, deterministic, and works offline. The dictionary can grow over time without any performance concern.
+- **No network calls**: Everything runs locally with bundled Lucide icons.
+- **Bundle size**: Phase A uses direct imports (~35 icons, tree-shaken, negligible cost). Phase B's icon picker requires the full `icons` wildcard import (~200KB gzipped) — lazy-load the picker component via `React.lazy()` to defer this cost until the user actually opens it.
+- **Extensibility**: The keyword dictionary is easy to extend — contributors can add entries without understanding complex code.
+- **Shared utility**: Phase A step 1 extracts `getColorForName()` to `src/lib/colors.ts`. Update `MCPIcon.tsx` to import from there in the same PR to avoid two copies.
+- **Icon picker UX**: Lucide has ~1500 icons. The picker should paginate or virtualize the grid, and search should filter by icon name. Consider showing "recently used" or "suggested" icons at the top.

--- a/issues/14-pending-skill-content-reconciliation.md
+++ b/issues/14-pending-skill-content-reconciliation.md
@@ -1,0 +1,111 @@
+# Issue 14: Cross-Tool Skill Content Reconciliation
+
+**Phase:** 2 (Write Capabilities)
+**Status:** Pending
+
+---
+
+## Summary
+
+Add a resolution flow for skills that have the same name but different content across tools. The backend already detects these conflicts (Issue 3) and the frontend already shows a warning banner (`ConflictWarning.tsx`), but there's no way for the user to **resolve** the discrepancy. This issue adds a side-by-side comparison view and a one-click sync to reconcile divergent skill versions.
+
+## What Already Exists
+
+- **Backend** (`src-tauri/src/scanners/skills.rs`): `SkillConflict` struct, `process_skill_entries()` groups by name, hashes content, returns conflicts
+- **Frontend** (`src/components/skills/ConflictWarning.tsx`): Banner listing skills with mismatched content across tools
+- Detection and warning are **done**. Resolution is **not**.
+
+## Motivation
+
+- Skills are often installed to multiple tools via Issue 5's sync feature, but subsequent edits happen in one tool's directory only
+- Without reconciliation, users unknowingly run different versions of the same skill across tools
+- The existing conflict warning tells users something is wrong but doesn't help them fix it
+- This is specific to **skills** (which have meaningful content/instructions) — rules and MCPs are less likely to diverge in the same way since MCPs are config entries and rules tend to be tool-specific
+
+## Acceptance Criteria
+
+- [ ] User can click a conflict warning to open a resolution dialog
+- [ ] Dialog lists each version with its source tool label and last-modified timestamp
+- [ ] Dialog shows a GitHub-style unified diff so the user can see what changed
+- [ ] User picks which version to keep
+- [ ] On selection, the chosen version is written to all other tool locations that have that skill
+- [ ] Uses the safe write infrastructure from Issue 5 (atomic writes, backups)
+- [ ] Dismissible: user can acknowledge a difference and choose to keep versions divergent
+
+## Technical Details
+
+### Backend: Extend Existing Conflict Data
+
+The existing `SkillConflict` struct has `name`, `conflicting_paths`, and `tools`. Extend it (or add a new command) to also return full content and last-modified timestamps for each version, so the frontend can display the comparison:
+
+```rust
+#[tauri::command]
+async fn get_skill_conflict_details(skill_name: String, paths: Vec<String>) -> Result<Vec<SkillVersion>, String>
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SkillVersion {
+    source_tool: String,
+    scope: String,
+    path: String,
+    content: String,
+    last_modified: Option<String>,  // filesystem mtime for "which is newer" hint
+}
+```
+
+### Backend: Resolution Command
+
+```rust
+#[tauri::command]
+async fn resolve_skill_conflict(
+    skill_name: String,
+    chosen_path: String,          // path of the version to keep
+    target_paths: Vec<String>,    // paths to overwrite with chosen version
+) -> Result<(), String>
+```
+
+### UI Components
+
+```
+src/components/skills/
+├── ConflictResolutionDialog.tsx  # Side-by-side comparison + pick version
+```
+
+- Make `ConflictWarning.tsx` clickable → opens `ConflictResolutionDialog`
+- **ConflictResolutionDialog**: Shows a GitHub-style unified diff between versions, with source tool labels and last-modified timestamps. User picks which version to keep or dismisses.
+- Use a lightweight diff library like `react-diff-viewer-continued` for the GitHub-style rendering
+
+### Files to Create/Modify
+
+```
+src-tauri/src/
+├── commands/skills.rs         # Add get_skill_conflict_details, resolve_skill_conflict
+
+src/
+├── lib/api/skills.ts          # Add conflict resolution API wrappers
+├── components/skills/
+│   ├── ConflictWarning.tsx     # Make clickable → opens resolution dialog
+│   └── ConflictResolutionDialog.tsx  # New
+```
+
+## Test Plan
+
+1. Create a skill `my-skill` in Claude and Codex with **identical** content → no conflict shown
+2. Edit the Codex version to differ → conflict indicator appears on the skill card
+3. Click "Review" → dialog shows both versions with source labels
+4. Pick the Claude version → Codex file is overwritten with Claude's content
+5. Verify backup created in `~/.loadout/backups/` before overwrite
+6. Verify both files now have identical content
+7. Dismiss a conflict → it no longer shows as a warning (until content changes again)
+8. Skill that exists in only one tool → no conflict indicator
+
+## Dependencies
+
+- Issue 3: Skills Scanner (conflict detection foundation)
+- Issue 5: Sync MCP + Skill (safe write infrastructure)
+
+## Notes
+
+- This feature is specific to **skills**. MCPs are config entries (not free-form content), and rules tend to be tool-specific, so cross-tool content divergence is less of a concern for those.
+- Consider scoping to user-level skills initially — project-level skills are tied to a specific workspace and less likely to be synced across tools.
+- The `last_modified` timestamp helps users make an informed choice but shouldn't auto-resolve (the older version might be intentionally different).

--- a/issues/15-pending-skill-best-practices-audit.md
+++ b/issues/15-pending-skill-best-practices-audit.md
@@ -1,0 +1,363 @@
+# Issue 15: Skill Best Practices Audit & Auto-Fix Pipeline
+
+**Phase:** 3 (AI Integration)
+**Status:** Pending
+
+---
+
+## Summary
+
+Add a feature that audits user skills against Anthropic's official skill authoring best practices, surfaces a scored report in the UI, and lets users selectively fix issues by dispatching corrections to a locally installed AI CLI (Claude Code, Codex, or Gemini).
+
+The pipeline has three stages:
+1. **Audit** — Send skill content + best practices reference to an AI CLI, receive a structured JSON report
+2. **Review** — Display the report in a rich UI with scores, pass/fail checks, and actionable findings
+3. **Fix** — User selects findings to fix, Loadout pushes them back to the CLI which rewrites the skill
+
+## Acceptance Criteria
+
+### Best Practices Reference
+
+- [ ] Store Anthropic's official best practices as a Markdown file at `src-tauri/resources/skill-best-practices.md`
+- [ ] File is bundled with the app binary (Tauri resource)
+- [ ] Tauri command `get_skill_best_practices()` returns the content to the frontend
+
+### Audit Flow
+
+- [ ] "Audit" button on each `SkillCard` and in `SkillViewer`
+- [ ] User selects which AI CLI to use (Claude Code / Codex / Gemini) — only installed CLIs shown
+- [ ] Loadout spawns the CLI in non-interactive mode with a prompt containing:
+  - The skill's full `SKILL.md` content
+  - The best practices reference document
+  - A JSON output schema for the audit report
+- [ ] CLI runs in the background with a progress spinner (60s timeout, cancel button)
+- [ ] CLI output is parsed as JSON; parsing errors show a retry option
+- [ ] Audit results are displayed in a dedicated Audit Report view
+
+### Audit Report JSON Schema
+
+- [ ] CLI is prompted to return a JSON object matching this structure
+- [ ] `overallScore` is determined holistically by the LLM (no deterministic formula enforced client-side). The prompt instructs the model to weigh categories based on relevance to the specific skill — e.g., "Code Quality" matters less for a markdown-only skill. If deterministic scoring is later preferred, compute it client-side as a weighted average of category scores.
+
+```jsonc
+{
+  "skillName": "processing-pdfs",
+  "overallScore": 82,              // 0-100
+  "summary": "Well-structured skill with minor naming and description issues.",
+  "categories": [
+    {
+      "name": "Naming",
+      "score": 70,
+      "maxScore": 100,
+      "findings": [
+        {
+          "id": "naming-gerund",
+          "severity": "warning",     // "error" | "warning" | "info"
+          "title": "Name should use gerund form",
+          "description": "Skill name 'pdf-tools' should use gerund form like 'processing-pdfs'.",
+          "suggestion": "Rename to 'processing-pdfs'",
+          "autoFixable": true
+        }
+      ]
+    },
+    {
+      "name": "Description",
+      "score": 90,
+      "maxScore": 100,
+      "findings": []
+    },
+    {
+      "name": "Structure",
+      "score": 85,
+      "maxScore": 100,
+      "findings": [
+        {
+          "id": "body-length",
+          "severity": "info",
+          "title": "SKILL.md body is under 500 lines",
+          "description": "Body is 120 lines — well within the recommended limit.",
+          "suggestion": null,
+          "autoFixable": false
+        }
+      ]
+    },
+    {
+      "name": "Content Quality",
+      "score": 80,
+      "maxScore": 100,
+      "findings": []
+    },
+    {
+      "name": "Progressive Disclosure",
+      "score": 75,
+      "maxScore": 100,
+      "findings": []
+    },
+    {
+      "name": "Terminology & Consistency",
+      "score": 90,
+      "maxScore": 100,
+      "findings": []
+    },
+    {
+      "name": "Workflows",
+      "score": 85,
+      "maxScore": 100,
+      "findings": []
+    },
+    {
+      "name": "Code Quality",
+      "score": 70,
+      "maxScore": 100,
+      "findings": [
+        {
+          "id": "magic-constants",
+          "severity": "warning",
+          "title": "Unexplained constants in scripts",
+          "description": "TIMEOUT = 47 has no justification comment.",
+          "suggestion": "Add a comment explaining why this value was chosen.",
+          "autoFixable": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Audit Report UI
+
+- [ ] Overall score displayed as a colored ring/badge (green >=80, yellow >=60, red <60)
+- [ ] Category breakdown with individual scores and expandable findings
+- [ ] Each finding shows severity icon, title, description, and suggestion
+- [ ] Findings with `autoFixable: true` have a selectable checkbox
+- [ ] "Fix Selected" button at the bottom (disabled when nothing selected)
+- [ ] "Re-audit" button to run the audit again after fixes
+
+### Auto-Fix Flow
+
+- [ ] User selects findings to fix via checkboxes, clicks "Fix Selected"
+- [ ] User selects which CLI to use for the fix (can differ from audit CLI)
+- [ ] Loadout spawns the CLI with a prompt containing:
+  - The current `SKILL.md` content
+  - The selected findings with their suggestions
+  - The best practices reference
+  - Instruction to output only the updated `SKILL.md` content
+- [ ] Updated content shown in an editable diff/preview before applying
+- [ ] User confirms → Loadout writes the updated file atomically (write to `.tmp`, rename over original)
+- [ ] A `.bak` backup of the original file is kept so the user can revert
+- [ ] After applying, auto-trigger a re-audit to show the new score
+
+### Audit Categories
+
+The audit should evaluate against these categories derived from the best practices:
+
+| Category | What it checks |
+|----------|---------------|
+| **Naming** | Gerund form, lowercase/hyphens, no reserved words, <=64 chars |
+| **Description** | Third person, specific terms, includes "when to use", <=1024 chars, no XML tags |
+| **Structure** | Body under 500 lines, progressive disclosure, one-level-deep refs, TOC for long files |
+| **Content Quality** | Conciseness, no unnecessary explanations, appropriate degrees of freedom |
+| **Progressive Disclosure** | Separate files for advanced content, no deeply nested refs |
+| **Terminology & Consistency** | Consistent terms, no time-sensitive info, forward-slash paths |
+| **Workflows** | Clear steps, feedback loops, checklists for complex tasks |
+| **Code Quality** | Scripts solve vs punt, no magic constants, explicit error handling, deps listed |
+
+## Technical Details
+
+### Best Practices Resource File
+
+Bundle the Anthropic best practices as a Tauri resource:
+
+```rust
+// src-tauri/tauri.conf.json — add to resources
+"bundle": {
+  "resources": ["resources/skill-best-practices.md"]
+}
+```
+
+```rust
+// src-tauri/src/commands/audit.rs
+#[tauri::command]
+fn get_skill_best_practices(app: tauri::AppHandle) -> Result<String, String> {
+    let resource_path = app.path()
+        .resolve("resources/skill-best-practices.md", tauri::path::BaseDirectory::Resource)
+        .map_err(|e| e.to_string())?;
+    std::fs::read_to_string(resource_path).map_err(|e| e.to_string())
+}
+```
+
+### Audit Command
+
+```rust
+#[tauri::command]
+async fn audit_skill(
+    skill_content: String,
+    best_practices: String,
+    cli: String,  // "claude", "codex", "gemini"
+) -> Result<SkillAuditReport, String> {
+    let prompt = format!(
+        "You are a skill quality auditor. Analyze the following SKILL.md against \
+         the best practices reference and output a JSON audit report.\n\n\
+         ## Best Practices Reference\n{}\n\n\
+         ## SKILL.md to Audit\n{}\n\n\
+         ## Output Format\n\
+         Output ONLY valid JSON matching the schema (no markdown fences).\n\
+         {}", // JSON schema here
+        best_practices, skill_content, AUDIT_SCHEMA
+    );
+
+    let output = spawn_cli(&cli, &prompt).await?;
+    serde_json::from_str(&output).map_err(|e| format!("Failed to parse audit JSON: {}", e))
+}
+```
+
+### Fix Command
+
+```rust
+#[tauri::command]
+async fn fix_skill(
+    skill_content: String,
+    findings: Vec<AuditFinding>,
+    best_practices: String,
+    cli: String,
+) -> Result<String, String> {
+    let findings_text = findings.iter()
+        .map(|f| format!("- {}: {}", f.title, f.suggestion.as_deref().unwrap_or("")))
+        .collect::<Vec<_>>().join("\n");
+
+    let prompt = format!(
+        "Update the following SKILL.md to fix these issues. \
+         Follow the best practices reference. Output ONLY the updated SKILL.md content.\n\n\
+         ## Issues to Fix\n{}\n\n\
+         ## Best Practices Reference\n{}\n\n\
+         ## Current SKILL.md\n{}",
+        findings_text, best_practices, skill_content
+    );
+
+    let output = spawn_cli(&cli, &prompt).await?;
+    Ok(strip_markdown_fences(&output))
+}
+```
+
+### Shared CLI Spawner
+
+Reuse the CLI detection and spawning logic from Issue 8 (`src-tauri/src/commands/ai.rs`).
+
+> **Important**: The exact CLI flags for non-interactive mode must be verified against each CLI's `--help` output at implementation time. Issue 8 owns the canonical `spawn_cli` implementation; this issue should not duplicate it.
+
+**Prompt delivery via stdin, not args**: The audit prompt (best practices + skill content + schema) can easily exceed OS `ARG_MAX` limits (~256KB on macOS). The `spawn_cli` helper must pipe the prompt via stdin rather than passing it as a command-line argument.
+
+```rust
+// Sketch — stdin-based approach
+let mut child = Command::new(cli_binary)
+    .args(cli_flags)        // non-interactive flags only, no prompt arg
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .spawn()
+    .map_err(|e| e.to_string())?;
+
+child.stdin.take().unwrap().write_all(prompt.as_bytes()).await?;
+let output = child.wait_with_output().await?;
+```
+
+This design change applies to Issue 8 as well — any prompt with bundled reference docs will hit the same limit.
+
+### Frontend Types
+
+```typescript
+// src/types/index.ts
+interface AuditFinding {
+  id: string;
+  severity: "error" | "warning" | "info";
+  title: string;
+  description: string;
+  suggestion: string | null;
+  autoFixable: boolean;
+}
+
+interface AuditCategory {
+  name: string;
+  score: number;
+  maxScore: number;
+  findings: AuditFinding[];
+}
+
+interface SkillAuditReport {
+  skillName: string;
+  overallScore: number;
+  summary: string;
+  categories: AuditCategory[];
+}
+```
+
+### Files to Create/Modify
+
+```
+# New files
+src-tauri/resources/skill-best-practices.md         # Anthropic best practices (bundled resource)
+src-tauri/src/commands/audit.rs                      # Audit + fix Tauri commands
+src/components/skills/AuditReport.tsx                # Audit report display
+src/components/skills/AuditButton.tsx                # Trigger audit from card/viewer
+src/lib/api/audit.ts                                 # API wrappers for audit commands
+
+# Modified files
+src-tauri/src/commands/mod.rs                        # Add audit module
+src-tauri/src/commands/ai.rs                         # Extract shared spawn_cli helper
+src-tauri/src/lib.rs                                 # Register audit commands
+src-tauri/tauri.conf.json                            # Add resources bundle entry
+src/components/skills/SkillCard.tsx                   # Add Audit button
+src/components/skills/SkillViewer.tsx                 # Add Audit button
+src/components/skills/index.ts                        # Export new components
+src/types/index.ts                                   # Add audit types
+```
+
+## Test Plan
+
+### Audit Flow
+1. Open a skill card, click "Audit"
+2. Verify only installed CLIs are shown as options
+3. Select Claude Code, confirm spinner appears
+4. Audit report appears with overall score and category breakdown
+5. Expand a category — findings listed with severity icons
+6. Click "Re-audit" — runs again, shows updated report
+
+### Fix Flow
+1. After audit, select 2-3 findings with `autoFixable: true`
+2. Click "Fix Selected", choose CLI
+3. Updated SKILL.md shown in editable preview
+4. Confirm — file is written to disk
+5. Verify `.bak` backup file was created alongside the original
+6. Auto re-audit runs, new score reflects fixes
+7. Verify the original file was actually updated on disk
+
+### Edge Cases
+1. Skill with perfect score → show congratulatory message, no fixable findings
+2. CLI timeout → show error with retry option
+3. CLI returns invalid JSON → show parse error, allow retry
+4. No CLIs installed → disable Audit button, show install guidance
+5. Skill file is read-only → show warning before attempting fix
+6. Very large skill (>500 lines) → audit still works, flags the length issue
+7. CLI takes >60s → timeout fires, cancel button works, partial output discarded
+8. Fix applied → `.bak` file exists and contains original content
+
+### JSON Validation
+1. Manually verify audit JSON matches the schema for 3+ different skills
+2. Test with minimal skill (name + description only)
+3. Test with complex skill (multiple files, scripts, workflows)
+
+## Dependencies
+
+- Issue 8: AI-Assisted Skill Creation (shared CLI spawning infrastructure)
+- Issue 3: Skills Scanner (skill content access — done)
+
+## Notes
+
+- **Best practices source**: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices — content should be copied as Markdown into `src-tauri/resources/skill-best-practices.md` and kept up to date periodically
+- **JSON output reliability**: LLMs can produce malformed JSON — consider retrying once on parse failure with a "fix this JSON" prompt, or use a lenient JSON parser
+- **Token budget**: The best practices doc is ~4k tokens. Combined with a skill and the schema prompt, this fits comfortably in a single CLI call. However, the raw character count (~16k+ chars) exceeds OS arg limits, so stdin piping is required (see Shared CLI Spawner section)
+- **Batch audit**: Future enhancement — "Audit All" button that runs audits across all discovered skills and shows a dashboard summary
+- **Score persistence**: Consider caching audit scores locally (Tauri store) so the SkillCard can show last-known score without re-running
+- **Diff preview**: For the fix flow, consider using a side-by-side diff view (e.g., `react-diff-viewer`) to show exactly what will change
+- Shares CLI detection logic with Issue 8 — extract into `src-tauri/src/commands/ai.rs` as a shared module
+- **CLI flags**: Exact non-interactive flags for each CLI must be verified at implementation time against `--help` output. Issue 8 owns the canonical implementation; do not hardcode flags here
+- **Write safety**: Fix flow uses atomic write (`.tmp` + rename) and keeps a `.bak` backup. Only one `.bak` is kept per skill (overwritten on subsequent fixes)

--- a/issues/16-pending-skills-marketplace.md
+++ b/issues/16-pending-skills-marketplace.md
@@ -1,0 +1,542 @@
+# Issue 16: Skills Marketplace
+
+**Phase:** 3 (Discovery)
+**Status:** Pending
+**Supersedes:** Issue 9 (Browse & Install from Skill Registry)
+
+---
+
+## Summary
+
+Build a full skills marketplace: a backend pipeline that discovers SKILL.md files on GitHub, scores them for quality and security, stores them in a database, and serves them through an API. The Tauri app consumes this API to let users browse, search, and install community skills. A companion web page provides the same browsing experience outside the app.
+
+This replaces Issue 9's assumption of consuming an external registry API. Instead, we build and own the entire pipeline: scraper, scoring, database, API, and both native + web frontends.
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    USER-FACING                           │
+│                                                         │
+│   Native App (Tauri)          Web Page (same data)      │
+│   ┌───────────────┐          ┌───────────────┐          │
+│   │ Browse/Search  │          │ Browse/Search  │         │
+│   │ Quality Scores │          │ Quality Scores │         │
+│   │ 1-Click Install│          │ Copy Command   │         │
+│   │ Install Stats  │          │ Install Stats  │         │
+│   └───────┬───────┘          └───────┬───────┘          │
+│           │                          │                   │
+└───────────┼──────────────────────────┼───────────────────┘
+            │                          │
+            ▼                          ▼
+┌─────────────────────────────────────────────────────────┐
+│                    BACKEND API                           │
+│                                                         │
+│   Skills Database (SQLite via D1 or Postgres)           │
+│   ┌─────────────────────────────────────────┐           │
+│   │ skill_id, name, description, repo_url,  │           │
+│   │ author, stars, forks, last_updated,     │           │
+│   │ quality_score, security_grade,          │           │
+│   │ install_count, category, role_tags      │           │
+│   └─────────────────────────────────────────┘           │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+            ▲                          ▲
+            │                          │
+┌───────────┼──────────────────────────┼───────────────────┐
+│           │     PIPELINE (Cron)      │                   │
+│           │                          │                   │
+│   ┌───────┴───────┐   ┌─────────────┴─────────┐        │
+│   │ GitHub Scraper │   │ Quality + Security    │        │
+│   │ (Daily)        │   │ Scorer (On new skills)│        │
+│   └───────────────┘   └───────────────────────┘        │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Acceptance Criteria
+
+### Phase A: GitHub Scraper Pipeline
+
+#### Discovery (daily cron)
+- [ ] Use GitHub Code Search API: `filename:SKILL.md` with YAML frontmatter pattern
+- [ ] Crawl known mega-repos directly via Contents API (anthropics/skills, alirezarezvani/claude-skills, VoltAgent/awesome-agent-skills, coreyhaines31/marketingskills, obra/superpowers)
+- [ ] For each result, fetch the raw SKILL.md content
+- [ ] Also fetch the repo tree listing for the skill's directory (siblings of SKILL.md) to detect supporting files (scripts/, references/, templates/) — needed for structural scoring and security scanning
+- [ ] Support incremental scans (only fetch new/updated since last run)
+
+#### Parsing
+- [ ] Extract YAML frontmatter (name, description)
+- [ ] Extract full markdown body
+- [ ] Pull repo-level metadata via GitHub REST API: stars, forks, last commit, contributor count, license, topics
+- [ ] Derive compatible agents from the skill's directory path context:
+  - Found under `.claude/skills/` or `.claude/commands/` → Claude Code
+  - Found under `.agents/skills/` or `.codex/skills/` → Codex
+  - Found under `.gemini/skills/` → Gemini
+  - Found under a generic `skills/` directory → all agents (standard SKILL.md format)
+  - Also check repo topics for agent-specific tags (e.g., `claude-code`, `cursor`, `codex`)
+
+#### Deduplication
+- [ ] Hash SKILL.md content to detect duplicates across forks
+- [ ] Keep the version from the repo with highest stars (canonical source)
+
+#### Licensing
+- [ ] Only index skills from repos with an OSI-approved license (MIT, Apache-2.0, BSD, ISC, etc.) or no license (treated as permissive for display, with a "No license" indicator)
+- [ ] Store license type in database; display on skill cards
+- [ ] Skills from repos with copyleft licenses (GPL, AGPL) are indexed but flagged — raw content is not served via API, only metadata + link to source repo
+- [ ] Include license attribution in the skill detail view when serving raw content
+
+#### Storage
+- [ ] Upsert into database with all metadata
+- [ ] Flag new/changed skills for quality scoring pipeline
+
+#### GitHub API Budget
+
+| API | Rate Limit | Cost |
+|-----|-----------|------|
+| Search API (code) | 30 requests/min (authenticated) | Free |
+| REST API (repo metadata) | 5,000 requests/hour (authenticated) | Free |
+| Contents API (fetch SKILL.md) | Part of 5,000/hour budget | Free |
+
+Initial scrape of the full universe (~10,000-20,000 unique skills) takes a few hours. Daily incremental scans need ~100-200 API calls total.
+
+---
+
+### Phase B: Quality & Security Scoring
+
+#### Structural Score (rule-based, free)
+- [ ] Has YAML frontmatter with name + description? (+1)
+- [ ] Description includes trigger phrases / "use when"? (+1)
+- [ ] Has examples section? (+1)
+- [ ] Has clear step-by-step instructions? (+1)
+- [ ] Uses progressive disclosure (references separate files)? (+1)
+- [ ] Total instructions < 500 lines (not bloated)? (+1)
+- [ ] Has supporting files (scripts/, references/, templates/)? (+1) — derived from repo tree listing fetched in Phase A, not from SKILL.md content
+- [ ] Score: 0-7, normalized to 0-100
+
+#### Author Reputation Score (rule-based, free)
+- [ ] Official team (Anthropic, Vercel, Stripe, Cloudflare, Google, etc.) → 100
+- [ ] Repo 1000+ stars → 80
+- [ ] Repo 100+ stars → 60
+- [ ] Repo 10+ stars → 40
+- [ ] Repo 2+ stars → 20
+- [ ] Below 2 stars → 0
+
+#### Freshness Score (rule-based, free)
+- [ ] Updated in last 30 days → 100
+- [ ] Updated in last 90 days → 75
+- [ ] Updated in last 6 months → 50
+- [ ] Updated in last year → 25
+- [ ] Older than 1 year → 0
+
+#### AI Quality Score (LLM-based)
+- [ ] Use Claude Code headless mode with Sonnet (`claude -p --model sonnet --output-format json`)
+- [ ] Evaluate: clarity, specificity, applicability, trigger quality, completeness (each 0-20, total 0-100)
+- [ ] Gate on structural score: skip AI scoring if structural score < 30
+- [ ] Hash-gated: only re-score when content changes
+- [ ] Run overnight to avoid interfering with daytime Opus usage
+
+#### Security Scanning
+- [ ] Rule-based scanner checks SKILL.md content and bundled scripts (fetched via repo tree listing from Phase A) for:
+  - URLs/endpoints to unknown domains (potential exfiltration)
+  - `curl`, `wget`, `fetch` commands to unknown domains
+  - References to environment variables, API keys, tokens
+  - Base64 encoded content (obfuscation)
+  - Instructions to ignore previous instructions (prompt injection)
+- [ ] Assign security grade: Verified / Review / Flagged
+- [ ] Optional: integrate Cisco skill-scanner static + behavioral analyzers
+
+#### Composite Score Formula
+```
+final_score = (
+    structural_score × 0.25 +
+    author_reputation × 0.20 +
+    freshness_score  × 0.15 +
+    ai_quality_score × 0.30 +
+    log(install_count + 1) × 0.10  # normalized 0-100
+)
+```
+
+---
+
+### Phase C: Backend API + Database
+
+#### Database Schema
+- [ ] `skills` table: skill_id, name, description, repo_url, author, stars, forks, last_updated, content_hash, quality_score, security_grade, install_count, category, role_tags, raw_content
+- [ ] `scoring_history` table: skill_id, score_type, score, scored_at, content_hash
+- [ ] Indexes on: name, quality_score, install_count, category, role_tags
+
+#### API Endpoints
+- [ ] `GET /skills` — paginated list with sort/filter (by score, category, role, freshness)
+- [ ] `GET /skills/:id` — full skill detail including raw SKILL.md content
+- [ ] `GET /skills/search?q=` — full-text search on name + description + tags
+- [ ] `GET /skills/collections` — role-based collections with counts
+- [ ] `POST /skills/:id/install` — anonymous install telemetry (no user ID, just aggregate count)
+- [ ] `GET /health` — service health check
+
+#### Hosting
+- [ ] Cloudflare Workers + D1 (SQLite) recommended for cost ($0-5/mo)
+- [ ] Alternative: Railway or Fly.io with Postgres if more flexibility needed
+
+---
+
+### Phase D: Marketplace UI in Tauri App
+
+#### Browse View
+- [ ] "Marketplace" tab/page accessible from main navigation
+- [ ] Default view: role-based collections (not a giant list)
+  - Product Manager, Software Engineer, UX/UI Designer, Content Marketing, Sales, Customer Success, Operations
+  - "Browse All (N skills)" link
+  - Trending This Week, Staff Picks, Recently Added, Official sections
+- [ ] Search bar with full-text search on name + description + tags
+- [ ] Filter by category/role tag
+- [ ] Sort by: quality score, install count, freshness, stars
+
+#### Skill Card
+- [ ] Name + 1-line description
+- [ ] Quality badge (S/A/B/C rank from composite score)
+- [ ] Security badge (Verified / Review / Flagged)
+- [ ] Install count
+- [ ] Source repo + stars
+- [ ] Compatible agents (Claude Code, Cursor, Codex, etc.)
+- [ ] "Install" button (1-click)
+
+#### Install Flow
+- [ ] Click "Install" → fetches full SKILL.md content from API
+- [ ] Show preview with tool selector (reuse existing InstallSkillDialog from Issue 5)
+- [ ] Installs to selected tools using existing write infrastructure
+- [ ] Sends anonymous install telemetry event to backend API
+- [ ] Shows success confirmation
+- [ ] Skill appears in local skills list after refresh
+
+#### Offline/Error States
+- [ ] Cache marketplace index locally via `tauri-plugin-store` for fast browsing
+- [ ] No internet → show cached results or "Marketplace unavailable" message
+- [ ] API error → show error with retry
+- [ ] Skill fetch fails → show error on specific skill
+
+---
+
+### Phase E: Install Telemetry
+
+- [ ] On skill install from marketplace, send anonymous event: `{skill_id, timestamp, agent_type}`
+- [ ] No user ID, no device ID — aggregate counts only
+- [ ] API increments `install_count` in database
+- [ ] Surface as "installed X times" on skill cards
+- [ ] Batch pending events and retry on network failure
+
+---
+
+### Phase F: Web Companion Page
+
+- [ ] Standalone web page consuming the same backend API
+- [ ] Browse/search skills with same data as native app
+- [ ] Quality scores, security badges, install counts displayed
+- [ ] "Copy command" instead of 1-click install (no native write access)
+- [ ] SEO-friendly for discoverability (server-rendered or static)
+
+---
+
+## Technical Details
+
+### Phase A: Scraper Implementation
+
+The scraper runs as a standalone script/service, not inside the Tauri app.
+
+```bash
+# GitHub Code Search for SKILL.md files
+curl -H "Authorization: token $GITHUB_PAT" \
+  "https://api.github.com/search/code?q=filename:SKILL.md"
+```
+
+Known mega-repos to crawl directly:
+- `anthropics/skills`
+- `alirezarezvani/claude-skills`
+- `VoltAgent/awesome-agent-skills`
+- `coreyhaines31/marketingskills`
+- `obra/superpowers`
+
+### Phase B: AI Scoring Pipeline
+
+Uses Claude Code headless mode with Sonnet to score skills at $0 incremental cost (existing Claude Max subscription).
+
+```bash
+# Score a single skill
+cat skill.md | claude -p \
+    "$(cat scoring-prompt.txt)" \
+    --model sonnet \
+    --output-format json \
+    --dangerously-skip-permissions
+```
+
+**Scoring prompt template:**
+```text
+You are evaluating an AI agent skill file (SKILL.md). Read the content provided via stdin
+and score it on 5 dimensions. Return ONLY valid JSON, no markdown fences, no other text.
+
+Dimensions (each 0-20, total 0-100):
+1. clarity — How clear and unambiguous are the instructions?
+2. specificity — Concrete steps, patterns, examples? Or vague hand-waving?
+3. applicability — Does this solve a real, practical task?
+4. trigger_quality — Is the description/trigger section clear about when to activate?
+5. completeness — Edge cases, errors, sufficient context?
+
+Return exactly this JSON shape:
+{"clarity":N,"specificity":N,"applicability":N,"trigger_quality":N,"completeness":N,"total":N,"rationale":"1-2 sentence summary"}
+```
+
+**Token budget:** ~2,700 tokens per skill (2,500 input + 200 output). 10,000 skills = ~27M tokens total overnight.
+
+**Rate limit note:** Sonnet pool is separate from Opus. Daytime coding on Opus is unaffected.
+
+**Alternative (TypeScript):** Claude Agent SDK for tighter integration:
+```typescript
+import { query } from "@anthropic-ai/claude-code";
+
+for await (const message of query({
+  prompt: `${SCORING_PROMPT}\n\nSKILL.md content:\n${skillContent}`,
+  options: { model: "sonnet", allowedTools: [] }
+})) { /* collect response */ }
+```
+
+Start with bash script to validate the approach. Migrate to Agent SDK when building the integrated backend.
+
+### Phase C: Database Schema
+
+```sql
+CREATE TABLE skills (
+    skill_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    repo_url TEXT NOT NULL,
+    repo_owner TEXT,
+    author TEXT,
+    stars INTEGER DEFAULT 0,
+    forks INTEGER DEFAULT 0,
+    license TEXT,
+    last_commit_at TEXT,
+    content_hash TEXT NOT NULL,
+    raw_content TEXT,
+    structural_score INTEGER,
+    author_score INTEGER,
+    freshness_score INTEGER,
+    ai_quality_score INTEGER,
+    composite_score INTEGER,
+    security_grade TEXT DEFAULT 'review',  -- 'verified', 'review', 'flagged'
+    install_count INTEGER DEFAULT 0,
+    category TEXT,
+    role_tags TEXT,  -- JSON array
+    topics TEXT,     -- JSON array from GitHub
+    compatible_agents TEXT,  -- JSON array: ["claude", "codex", "gemini", "cursor", etc.]
+    has_supporting_files BOOLEAN DEFAULT FALSE,  -- TRUE if repo tree has sibling dirs (scripts/, etc.)
+    scraped_at TEXT NOT NULL,
+    scored_at TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_skills_composite ON skills(composite_score DESC);
+CREATE INDEX idx_skills_category ON skills(category);
+CREATE INDEX idx_skills_name ON skills(name);
+```
+
+### Phase D: Tauri App Integration
+
+#### Frontend Types
+
+```typescript
+// src/types/index.ts
+interface MarketplaceSkill {
+  skillId: string;
+  name: string;
+  description: string;
+  repoUrl: string;
+  author: string;
+  stars: number;
+  forks: number;
+  lastCommitAt: string;
+  compositeScore: number;
+  securityGrade: "verified" | "review" | "flagged";
+  installCount: number;
+  category: string;
+  roleTags: string[];
+  compatibleAgents: string[];  // ["claude", "codex", "gemini", "cursor", etc.]
+}
+
+interface MarketplaceCollection {
+  role: string;
+  count: number;
+  topSkills: MarketplaceSkill[];
+}
+
+interface MarketplaceSearchResult {
+  skills: MarketplaceSkill[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+```
+
+#### API Wrapper
+
+```typescript
+// src/lib/api/marketplace.ts
+const API_BASE = "https://api.loadout.dev"; // or env-configured
+
+export async function fetchCollections(): Promise<MarketplaceCollection[]> { ... }
+export async function searchSkills(query: string, filters: object): Promise<MarketplaceSearchResult> { ... }
+export async function fetchSkillDetail(id: string): Promise<MarketplaceSkill & { rawContent: string }> { ... }
+export async function reportInstall(skillId: string, agentType: string): Promise<void> { ... }
+```
+
+#### Caching
+
+```typescript
+import { Store } from "@tauri-apps/plugin-store";
+const store = new Store("marketplace-cache");
+await store.set("collections", { data: collections, fetchedAt: Date.now() });
+// Serve from cache if < 1 hour old, refresh in background
+```
+
+### Files to Create/Modify
+
+```
+# Backend service (separate repo or monorepo subfolder)
+marketplace/
+├── scraper/
+│   ├── github-scraper.ts         # GitHub Code Search + Contents API
+│   ├── parser.ts                 # SKILL.md frontmatter + metadata extraction
+│   └── deduplicator.ts           # Content-hash dedup across forks
+├── scoring/
+│   ├── structural.ts             # Rule-based structural scoring
+│   ├── reputation.ts             # Author/repo reputation scoring
+│   ├── freshness.ts              # Last-commit freshness scoring
+│   ├── ai-scorer.sh              # Claude Code headless scoring script
+│   ├── scoring-prompt.txt        # Scoring prompt template
+│   └── security.ts               # Rule-based security scanner
+├── api/
+│   ├── worker.ts                 # Cloudflare Worker (or Express)
+│   └── routes.ts                 # API route handlers
+├── schema.sql                    # Database schema
+└── wrangler.toml                 # Cloudflare config (if using Workers + D1)
+
+# Tauri app changes (this repo)
+src/
+├── pages/Marketplace.tsx                    # New page
+├── components/marketplace/
+│   ├── MarketplaceBrowser.tsx               # Main browse view with collections
+│   ├── MarketplaceSkillCard.tsx             # Individual skill card
+│   ├── MarketplaceSearch.tsx                # Search + filter bar
+│   ├── CollectionGrid.tsx                   # Role-based collection tiles
+│   ├── QualityBadge.tsx                     # S/A/B/C rank display
+│   ├── SecurityBadge.tsx                    # Verified/Review/Flagged
+│   └── index.ts                             # Barrel export
+├── lib/api/marketplace.ts                   # API wrapper
+├── types/index.ts                           # Add marketplace types
+
+# Web companion (separate repo or subfolder)
+web/
+├── src/
+│   ├── pages/                    # Browse, search, skill detail pages
+│   └── components/               # Reusable UI (can share with Tauri via package)
+```
+
+---
+
+## Test Plan
+
+### Phase A: Scraper
+1. Run scraper against GitHub Code Search → verify SKILL.md files discovered
+2. Parse 10+ diverse SKILL.md files → frontmatter + metadata extracted correctly
+3. Create two repos with identical SKILL.md content → deduplicator keeps higher-star version
+4. Run incremental scan after initial → only new/updated skills fetched
+5. Verify repo metadata (stars, forks, license, topics) populated correctly
+
+### Phase B: Scoring
+1. Score a well-structured skill (frontmatter, examples, steps) → structural score > 70
+2. Score a minimal skill (no frontmatter, no examples) → structural score < 30
+3. Score a skill from anthropics/ repo → author reputation = 100
+4. Score a skill updated today → freshness = 100
+5. Run AI scorer on 10 skills → valid JSON responses with scores 0-100
+6. Verify structural score < 30 gates AI scoring (skipped)
+7. Re-score unchanged skill → hash match, scoring skipped
+8. Run security scanner on skill with `curl` to unknown domain → flagged
+9. Run security scanner on clean skill → verified
+
+### Phase C: API
+1. `GET /skills` → paginated list sorted by composite score
+2. `GET /skills/search?q=commit` → returns matching skills
+3. `GET /skills/:id` → full detail with raw SKILL.md content
+4. `GET /skills/collections` → role-based collections with counts
+5. `POST /skills/:id/install` → install count incremented
+6. API returns proper error codes for missing skills, bad queries
+
+### Phase D: Marketplace UI
+1. Open Marketplace page → role-based collections displayed
+2. Click a collection → filtered list of skills for that role
+3. Search "commit" → matching skills shown
+4. Skill card shows: name, description, quality badge, security badge, install count, stars
+5. Click "Install" → preview dialog with tool selector
+6. Install completes → skill appears in local Skills list
+7. No internet → cached results shown or "unavailable" message
+8. API error → error state with retry button
+
+### Phase E: Telemetry
+1. Install a skill from marketplace → install count increments on backend
+2. Install while offline → event queued, sent when online
+3. Verify no user ID or device ID in telemetry payload
+
+### Phase F: Web Page
+1. Browse skills → same data as native app
+2. Search works → returns same results as API
+3. Skill detail shows quality/security badges
+4. "Copy command" button works (no Install button on web)
+
+---
+
+## Dependencies
+
+- Issue 5: Sync MCP + Skill (write infrastructure for install flow) — done
+- Issue 7: Import from URL (for fetching SKILL.md content from GitHub URLs)
+- Issue 8: AI-Assisted Skill Creation (shared CLI spawning infrastructure for AI scoring)
+- Supersedes Issue 9: Browse & Install from Skill Registry
+
+---
+
+## Cost Summary
+
+### Monthly Running Costs (Steady State)
+
+| Component | Cost | Notes |
+|-----------|------|-------|
+| GitHub API scraping | $0 | Free with PAT |
+| Structural / reputation / freshness scoring | $0 | Rule-based |
+| AI quality scoring (incremental) | $0 | Claude Code Sonnet (existing subscription) |
+| Security scanning (static) | $0 | Rule-based |
+| Database + API hosting | $5-20/mo | Cloudflare Workers + D1 or small VPS |
+| **Total** | **$5-20/mo** | |
+
+### One-Time Initial Costs
+
+| Component | Cost | Notes |
+|-----------|------|-------|
+| Initial full scrape + AI scoring | $0 | Overnight run on Sonnet |
+| Initial security scan | $0 | Static analysis |
+
+---
+
+## Notes
+
+- **Start narrow**: Scrape top 20 repos + their forks first, expand later. Don't index 200K skills day one — most are junk.
+- **Score lazily**: Only AI-score the top 2,000-3,000 skills (from repos with 10+ stars). Score lower-quality repos on demand (first search hit or first install).
+- **Cache aggressively**: SKILL.md content rarely changes. Hash the content, only re-score on hash change.
+- **Structural score as gate**: If structural score < 30, skip AI scoring entirely.
+- **Run overnight**: Schedule AI scoring during off-hours when Opus development sessions are inactive.
+- **Community signal as filter**: Once telemetry is live, only AI-score skills that get at least 1 install.
+- **Monitor quota**: Check Sonnet usage after initial runs. If tighter than expected, reduce parallelism or add longer sleep intervals.
+- **Fallback**: If scoring volume exceeds Sonnet subscription quota, fall back to Haiku Batch API at ~$0.00175/skill.
+- **Cisco skill-scanner**: Consider integrating its static + behavioral analyzers (Apache 2.0) for deeper security scanning after MVP.
+- **Web companion**: Could be a simple static site (Astro, Next.js) consuming the same API. SEO matters for discoverability.
+- **This is the moat**: The unique combo of native app install telemetry + AI scoring + security scanning + role-based curation — nobody else has all four.

--- a/issues/17-pending-mcp-marketplace.md
+++ b/issues/17-pending-mcp-marketplace.md
@@ -1,0 +1,197 @@
+# Issue 17: MCP Marketplace
+
+**Phase:** 3 (Discovery)
+**Status:** Pending
+
+---
+
+## Summary
+
+Add MCP servers to the marketplace experience so users can browse, evaluate, and install MCPs with one click.
+
+Unlike skills discovery (GitHub `SKILL.md` crawling), MCP discovery should be **registry-first**:
+- ingest official MCP Registry metadata,
+- sync incrementally using pagination + timestamp filters,
+- enrich with optional third-party signals,
+- audit for security/trust before surfacing as "recommended".
+
+This issue introduces MCP-specific backend ingestion/scoring plus marketplace UI integration.
+
+---
+
+## Acceptance Criteria
+
+### Phase A: MCP Source Ingestion
+
+#### Official Registry Sync
+- [ ] Add a standalone MCP ingestion job (outside Tauri app)
+- [ ] Pull from official MCP Registry API (`/v0.1/servers`)
+- [ ] Support incremental sync via:
+  - cursor pagination (`nextCursor`)
+  - `updated_since` filter
+- [ ] Persist registry status transitions (`active`, `deprecated`, `deleted`)
+- [ ] Keep "last successful sync" checkpoint for resumable ingestion
+- [ ] Backfill mode for first full import
+
+#### Normalization
+- [ ] Normalize package/source metadata (npm, PyPI, Docker, GitHub, URL/custom)
+- [ ] Normalize transport/runtime shape (stdio vs HTTP/SSE)
+- [ ] Extract installation hints usable by Loadout add/sync flows
+- [ ] Track source provenance (`official`, `third_party`, `curated`)
+
+#### Optional Enrichment Sources
+- [ ] Add optional enrichment ingest from curated registries/directories
+- [ ] Never override official registry identity fields with enrichment data
+- [ ] Store enrichment data separately with source + freshness metadata
+
+---
+
+### Phase B: MCP Trust + Audit Pipeline
+
+#### Static Audit (Rule-based)
+- [ ] Detect risky install commands or shell chains
+- [ ] Flag unknown/suspicious domains in HTTP endpoints
+- [ ] Flag broad or sensitive env var requirements (tokens, cloud keys)
+- [ ] Flag risky runtime hints (root/sudo/bypass patterns)
+- [ ] Generate audit findings with severity (`low`/`medium`/`high`)
+
+#### Supply-Chain Signals
+- [ ] Validate package existence and publisher metadata where possible
+- [ ] Capture basic maturity signals (release recency, repo stars if available)
+- [ ] Flag package typosquat heuristics (near-match names) for review
+
+#### Runtime Health Integration
+- [ ] Reuse Issue 6 health testing model for opt-in runtime checks
+- [ ] Track latest handshake health result separately from static trust
+- [ ] Display "health unknown" by default until explicitly tested
+
+#### Trust Grade
+- [ ] Assign marketplace trust grade: `verified` / `review` / `flagged`
+- [ ] Keep reasoning payload for each grade for explainability in UI
+
+---
+
+### Phase C: Backend API + Database
+
+#### Database
+- [ ] `mcp_servers` table with canonical metadata + status
+- [ ] `mcp_audits` table for rule findings + trust grade history
+- [ ] `mcp_install_events` table for aggregate install counts
+- [ ] Indexes on: name, status, trust_grade, install_count, updated_at
+
+#### API Endpoints
+- [ ] `GET /mcps` — paginated MCP list with sort/filter
+- [ ] `GET /mcps/:id` — full MCP detail + audit summary
+- [ ] `GET /mcps/search?q=` — full-text search
+- [ ] `POST /mcps/:id/install` — aggregate install telemetry
+- [ ] `POST /mcps/:id/test` (optional proxy) — hook into existing health test flow
+
+---
+
+### Phase D: Marketplace UI Integration
+
+#### Unified Marketplace Shell
+- [ ] Marketplace adds content-type switch: `Skills` | `MCPs` | `Agents`
+- [ ] Preserve shared UX patterns (search, filters, sort, card/list views)
+
+#### MCP Browse View
+- [ ] MCP cards display: name, description, source, status, trust badge, install count
+- [ ] Show transport/runtime details (stdio/http) and compatibility by tool
+- [ ] Show deprecated/deleted status prominently
+- [ ] Filter by trust grade, status, transport, tool compatibility
+
+#### MCP Install Flow
+- [ ] Click "Install" pre-fills existing Add MCP dialog/write flow (Issue 5)
+- [ ] Preview exact command/args/env mapping before write
+- [ ] Optional "Test after install" hook into Issue 6
+- [ ] Emit anonymous install telemetry
+
+#### Offline/Error States
+- [ ] Cache MCP marketplace index in local store
+- [ ] Offline: show cached data with "stale" indicator
+- [ ] API failures: retry UX and partial rendering support
+
+---
+
+## Technical Details
+
+### Sync Strategy
+
+1. Full sync once (paged by cursor)
+2. Save checkpoint `{last_updated_since, last_cursor}`
+3. Incremental runs use `updated_since=<checkpoint>`
+4. Continue paging with `cursor` until exhausted
+5. Upsert new/changed items, apply status updates, record sync watermark
+
+### Proposed Types
+
+```typescript
+interface MarketplaceMCP {
+  mcpId: string;
+  name: string;
+  description: string;
+  source: "official" | "third_party" | "curated";
+  status: "active" | "deprecated" | "deleted";
+  trustGrade: "verified" | "review" | "flagged";
+  transport: "stdio" | "http" | "sse" | "unknown";
+  installCount: number;
+  compatibleTools: ("claude" | "codex" | "gemini" | "cursor")[];
+  lastUpdatedAt: string;
+}
+```
+
+### Files to Create/Modify
+
+```
+# Backend service
+marketplace/
+├── mcp-ingest/
+│   ├── registry-client.ts
+│   ├── incremental-sync.ts
+│   └── normalizer.ts
+├── mcp-audit/
+│   ├── static-rules.ts
+│   ├── supply-chain.ts
+│   └── trust-grade.ts
+├── api/
+│   └── mcp-routes.ts
+└── schema-mcp.sql
+
+# Tauri app
+src/
+├── components/marketplace/MCPCard.tsx
+├── components/marketplace/MCPFilters.tsx
+├── lib/api/marketplace.ts              # add MCP endpoints
+└── types/index.ts                      # add MarketplaceMCP types
+```
+
+---
+
+## Test Plan
+
+1. Run full MCP ingest from empty DB -> records imported with canonical IDs
+2. Run incremental sync with `updated_since` -> only changed/new records processed
+3. Registry item marked deprecated -> UI shows deprecated badge and warning
+4. Registry item marked deleted -> item hidden from default browse, visible in admin/debug
+5. Static audit flags suspicious endpoint -> trust grade downgraded to `review`/`flagged`
+6. Install MCP from marketplace -> existing write flow creates tool config entries
+7. Optional test flow -> health result stored/displayed without auto-running commands
+8. Offline browse -> cached MCP data visible with stale indicator
+
+---
+
+## Dependencies
+
+- Issue 2: MCP Registry (done)
+- Issue 5: Sync MCP + Skill (done, reuse write flow)
+- Issue 6: MCP Health Testing (pending, runtime validation)
+- Issue 16: Skills Marketplace (pending, shared marketplace shell/API patterns)
+
+---
+
+## Notes
+
+- Discovery model differs from skills: **registry-first**, not GitHub-file-first.
+- Keep official registry metadata authoritative.
+- Treat enrichment signals as advisory, not source of truth.
+- Never execute untrusted commands automatically during ingestion/audit.

--- a/issues/18-pending-subagents-marketplace.md
+++ b/issues/18-pending-subagents-marketplace.md
@@ -1,0 +1,192 @@
+# Issue 18: Subagents Marketplace
+
+**Phase:** 3 (Discovery)
+**Status:** Pending
+
+---
+
+## Summary
+
+Add subagents (Agents) to the marketplace so users can discover and install reusable agent definitions from community sources.
+
+Subagent discovery should not follow MCP's registry-first model because there is no strong canonical public registry yet. The right approach is:
+- curated-source indexing first,
+- targeted GitHub discovery for agent file patterns,
+- frontmatter/body parsing and quality scoring,
+- safety scanning before installation.
+
+This issue adds subagent ingestion/scoring and integrates it into the same marketplace surface as Skills and MCPs.
+
+---
+
+## Acceptance Criteria
+
+### Phase A: Agent Discovery Pipeline
+
+#### Source Strategy
+- [ ] Build curated source list (official docs/examples + high-quality repos)
+- [ ] Add GitHub discovery for likely agent paths:
+  - `.claude/agents/*.md`
+  - `.gemini/agents/*.md`
+  - `agents/*.md` (curated repos only)
+- [ ] Support incremental scanning by commit timestamp/hash
+- [ ] Keep source attribution (`official`, `curated`, `community`)
+
+#### Parsing + Extraction
+- [ ] Parse YAML frontmatter + markdown body
+- [ ] Extract key fields: `name`, `description`, `tools`, `model`, `maxTurns`, `permissionMode`
+- [ ] Support plain markdown fallback with filename-based identity
+- [ ] Infer compatible tools from path + metadata:
+  - Claude agents paths -> Claude
+  - Gemini agents paths -> Gemini
+  - Codex -> not supported (explicitly marked)
+
+#### Dedup + Canonicalization
+- [ ] Deduplicate by normalized content hash
+- [ ] Pick canonical source based on trust rank (`official > curated > community`) then stars
+- [ ] Keep alias mapping for duplicate copies/forks
+
+---
+
+### Phase B: Agent Quality + Safety Scoring
+
+#### Structural Quality (Rule-based)
+- [ ] Frontmatter presence and required fields quality
+- [ ] Clarity of invocation conditions in description
+- [ ] Prompt specificity and actionable steps
+- [ ] Reasonable defaults for `maxTurns` and permission mode
+- [ ] Structural score 0-100
+
+#### AI Quality Review (Optional)
+- [ ] LLM-based rubric for clarity/completeness/task fit
+- [ ] Hash-gated scoring (re-score only on content change)
+- [ ] Gate expensive scoring behind structural threshold
+
+#### Safety Audit
+- [ ] Flag instructions that push unsafe permission escalation by default
+- [ ] Flag prompt-injection style patterns ("ignore previous instructions", hidden exfiltration cues)
+- [ ] Flag suspicious external command guidance or secret-handling anti-patterns
+- [ ] Assign safety grade: `verified` / `review` / `flagged`
+
+---
+
+### Phase C: Backend API + Database
+
+#### Database
+- [ ] `agents_marketplace` table with parsed fields + provenance
+- [ ] `agent_scoring_history` table for quality/safety score history
+- [ ] `agent_install_events` table for aggregate install counts
+- [ ] Indexes on: name, score, safety_grade, source_type, compatible_tools
+
+#### API Endpoints
+- [ ] `GET /agents` — paginated list with filters/sort
+- [ ] `GET /agents/:id` — full agent definition + metadata
+- [ ] `GET /agents/search?q=` — search by name/description/tools
+- [ ] `POST /agents/:id/install` — aggregate install telemetry
+
+---
+
+### Phase D: Marketplace UI Integration
+
+#### Unified Marketplace Shell
+- [ ] Marketplace content-type switch supports `Skills` | `MCPs` | `Agents`
+- [ ] Shared search/filter UX with type-specific filter extensions
+
+#### Agent Browse View
+- [ ] Agent cards show: name, description, source, quality badge, safety badge, install count
+- [ ] Show model/tools metadata at a glance
+- [ ] Show compatibility badges (Claude, Gemini; Codex marked unsupported)
+- [ ] Filter by source type, compatibility, score, recency
+
+#### Agent Install Flow
+- [ ] Click "Install" reuses `install_agent_to_tools` flow from Issue 10
+- [ ] Show full preview (frontmatter + body) before install
+- [ ] Let user choose scope (user/project) and target tools
+- [ ] Emit anonymous install telemetry
+
+#### Offline/Error States
+- [ ] Cache agent marketplace index locally
+- [ ] Offline: cached results + stale indicator
+- [ ] Per-item fetch failures handled without breaking whole list
+
+---
+
+## Technical Details
+
+### Discovery Heuristics
+
+- Prioritize repositories that already match known agent conventions
+- Restrict broad GitHub code search to avoid indexing arbitrary prompts as "agents"
+- Record confidence score for each detected agent candidate
+
+### Proposed Types
+
+```typescript
+interface MarketplaceAgent {
+  agentId: string;
+  name: string;
+  description: string;
+  sourceType: "official" | "curated" | "community";
+  qualityScore: number;
+  safetyGrade: "verified" | "review" | "flagged";
+  installCount: number;
+  model: string | null;
+  tools: string | null;
+  compatibleTools: ("claude" | "gemini" | "codex")[];
+  lastUpdatedAt: string;
+}
+```
+
+### Files to Create/Modify
+
+```
+# Backend service
+marketplace/
+├── agent-ingest/
+│   ├── github-discovery.ts
+│   ├── parser.ts
+│   └── deduplicator.ts
+├── agent-scoring/
+│   ├── structural.ts
+│   ├── ai-quality.ts
+│   └── safety.ts
+├── api/
+│   └── agent-routes.ts
+└── schema-agents.sql
+
+# Tauri app
+src/
+├── components/marketplace/AgentCard.tsx
+├── components/marketplace/AgentFilters.tsx
+├── lib/api/marketplace.ts              # add Agent endpoints
+└── types/index.ts                      # add MarketplaceAgent types
+```
+
+---
+
+## Test Plan
+
+1. Discover agents from curated repo set -> parsed fields populated correctly
+2. Parse frontmatter agent + plain markdown fallback agent -> both supported
+3. Duplicate agent content across repos -> deduplicator picks canonical source correctly
+4. Agent with risky permission guidance -> flagged by safety audit
+5. Browse Agents tab -> cards render compatibility badges correctly
+6. Install agent from marketplace -> writes `.claude/agents`/`.gemini/agents` files via existing sync path
+7. Attempt Codex target -> disabled with explicit "not supported" indicator
+8. Offline mode -> cached agent results still browsable
+
+---
+
+## Dependencies
+
+- Issue 10: Subagents Scanner + Sync (pending, provides parser/write/install primitives)
+- Issue 16: Skills Marketplace (pending, shared marketplace shell/API patterns)
+- Issue 17: MCP Marketplace (pending, aligns unified multi-type marketplace architecture)
+
+---
+
+## Notes
+
+- UI label should remain "Agents" for consistency with existing product language.
+- Subagent ecosystems are fragmented today; curated-source governance is critical.
+- Keep discovery confidence and provenance visible to avoid over-trusting weak sources.


### PR DESCRIPTION
Add comprehensive specifications for 7 pending features:

- Issue 12: Test data fixtures for development and demos
- Issue 13: Skill icon assets and display
- Issue 14: Skill content reconciliation
- Issue 15: Skill best practices audit
- Issue 16: Skills marketplace
- Issue 17: MCP marketplace
- Issue 18: Subagents marketplace

These specs include acceptance criteria, technical details, and test plans to guide implementation.