### PR TITLE
feat: Add reveal-in-file-manager for config files

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,8 +2,10 @@ pub mod config;
 pub mod mcps;
 pub mod skills;
 pub mod sync;
+pub mod system;
 
 pub use config::*;
 pub use mcps::*;
 pub use skills::*;
 pub use sync::*;
+pub use system::*;

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,0 +1,97 @@
+//! Tauri commands for interacting with the host system shell.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn nearest_existing_path(path: &Path) -> Option<PathBuf> {
+    if path.exists() {
+        return Some(path.to_path_buf());
+    }
+
+    let mut current = path.parent();
+    while let Some(parent) = current {
+        if parent.exists() {
+            return Some(parent.to_path_buf());
+        }
+        current = parent.parent();
+    }
+
+    None
+}
+
+/// Reveal a file or directory in the native file manager.
+///
+/// - macOS: Finder (`open -R` for files)
+/// - Windows: Explorer (`/select,` for files)
+/// - Linux: Opens the directory in default file manager
+#[tauri::command]
+pub fn reveal_in_file_manager(path: String) -> Result<(), String> {
+    let requested = PathBuf::from(&path);
+    let target = nearest_existing_path(&requested)
+        .ok_or_else(|| format!("Path does not exist and no parent found: {}", path))?;
+    let is_file = target.is_file();
+
+    let status = if cfg!(target_os = "macos") {
+        let mut cmd = Command::new("open");
+        if is_file {
+            cmd.arg("-R").arg(&target);
+        } else {
+            cmd.arg(&target);
+        }
+        cmd.status()
+    } else if cfg!(target_os = "windows") {
+        let mut cmd = Command::new("explorer");
+        if is_file {
+            cmd.arg(format!("/select,{}", target.to_string_lossy()));
+        } else {
+            cmd.arg(&target);
+        }
+        cmd.status()
+    } else {
+        // Most Linux file managers do not support selecting a specific file reliably.
+        let open_target = if is_file {
+            target
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| target.clone())
+        } else {
+            target.clone()
+        };
+
+        Command::new("xdg-open").arg(open_target).status()
+    }
+    .map_err(|e| format!("Failed to open file manager: {}", e))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "File manager command exited with status: {}",
+            status
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_existing_path_as_is() {
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().join("file.txt");
+        std::fs::write(&existing, "x").unwrap();
+
+        let resolved = nearest_existing_path(&existing).unwrap();
+        assert_eq!(resolved, existing);
+    }
+
+    #[test]
+    fn falls_back_to_existing_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("a").join("b").join("c.txt");
+
+        let resolved = nearest_existing_path(&missing).unwrap();
+        assert_eq!(resolved, dir.path().to_path_buf());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,8 +10,9 @@ mod workspace;
 mod writers;
 
 use commands::{
-    add_mcp_to_tools, fetch_mcp_tools, install_skill_to_tools, preview_mcp_configs, scan_hooks,
-    scan_mcps, scan_rules, scan_skills, sync_mcp_to_tools, test_mcp_health,
+    add_mcp_to_tools, fetch_mcp_tools, install_skill_to_tools, preview_mcp_configs,
+    reveal_in_file_manager, scan_hooks, scan_mcps, scan_rules, scan_skills, sync_mcp_to_tools,
+    test_mcp_health,
 };
 use scanners::workspaces::{discover_workspaces, DiscoveryResult};
 
@@ -112,6 +113,7 @@ pub fn run() {
             sync_mcp_to_tools,
             test_mcp_health,
             fetch_mcp_tools,
+            reveal_in_file_manager,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/scanners/hooks.rs
+++ b/src-tauri/src/scanners/hooks.rs
@@ -28,6 +28,8 @@ pub struct HookItem {
     pub command: String,
     /// Action type (e.g., "command")
     pub action_type: String,
+    /// Path to the source config file
+    pub path: String,
 }
 
 /// Result of scanning all hooks
@@ -56,7 +58,11 @@ pub fn scan_all_hooks() -> Result<HookScanResult, String> {
                             event: event.clone(),
                             matcher: matcher_entry.matcher.clone(),
                             command: cmd.clone(),
-                            action_type: action.action_type.clone().unwrap_or_else(|| "command".to_string()),
+                            action_type: action
+                                .action_type
+                                .clone()
+                                .unwrap_or_else(|| "command".to_string()),
+                            path: claude_settings_path.to_string_lossy().to_string(),
                         });
                     }
                 }
@@ -78,7 +84,11 @@ pub fn scan_all_hooks() -> Result<HookScanResult, String> {
                         event: event.clone(),
                         matcher: matcher_entry.matcher.clone(),
                         command: cmd.clone(),
-                        action_type: action.action_type.clone().unwrap_or_else(|| "command".to_string()),
+                        action_type: action
+                            .action_type
+                            .clone()
+                            .unwrap_or_else(|| "command".to_string()),
+                        path: gemini_settings_path.to_string_lossy().to_string(),
                     });
                 }
             }
@@ -110,6 +120,7 @@ mod tests {
             matcher: Some("Bash|Write".to_string()),
             command: "/path/to/script.sh".to_string(),
             action_type: "command".to_string(),
+            path: "/Users/test/.claude/settings.json".to_string(),
         };
 
         let json = serde_json::to_string(&hook).unwrap();

--- a/src/components/config/HooksSection.tsx
+++ b/src/components/config/HooksSection.tsx
@@ -1,6 +1,7 @@
 import { Anchor, AlertTriangle } from "lucide-react";
 import type { HookItem } from "@/types";
 import { cn } from "@/lib/utils";
+import { OpenPathButton } from "@/components/ui/open-path-button";
 
 interface HooksSectionProps {
   hooks: HookItem[];
@@ -80,6 +81,9 @@ export function HooksSection({ hooks, geminiHooksEnabled }: HooksSectionProps) {
                   <th className="px-3 py-2 text-left font-medium text-muted-foreground">
                     Command
                   </th>
+                  <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+                    Config
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -114,6 +118,15 @@ export function HooksSection({ hooks, geminiHooksEnabled }: HooksSectionProps) {
                       title={hook.command}
                     >
                       {hook.command}
+                    </td>
+                    <td className="px-3 py-2">
+                      <OpenPathButton
+                        path={hook.path}
+                        variant="ghost"
+                        size="sm"
+                        label="Open Config"
+                        className="h-7 px-2 text-xs"
+                      />
                     </td>
                   </tr>
                 ))}

--- a/src/components/config/RuleViewer.tsx
+++ b/src/components/config/RuleViewer.tsx
@@ -4,6 +4,7 @@ import type { PromptFile } from "@/types";
 import { ToolBadge } from "@/components/mcps/ToolBadge";
 import { TokenBadge } from "@/components/context";
 import { Button } from "@/components/ui/button";
+import { OpenPathButton } from "@/components/ui/open-path-button";
 
 interface RuleViewerProps {
   rule: PromptFile;
@@ -102,11 +103,18 @@ export function RuleViewer({ rule, onClose }: RuleViewerProps) {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center gap-2 border-t border-border px-4 py-2 text-xs text-muted-foreground">
-          <FolderOpen className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate font-mono" title={rule.path}>
-            {rule.path}
-          </span>
+        <div className="flex items-center justify-between gap-4 border-t border-border px-4 py-2 text-xs text-muted-foreground">
+          <div className="flex min-w-0 items-center gap-2">
+            <FolderOpen className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate font-mono" title={rule.path}>
+              {rule.path}
+            </span>
+          </div>
+          <OpenPathButton
+            path={rule.path}
+            variant="outline"
+            size="sm"
+          />
         </div>
       </div>
     </div>

--- a/src/components/mcps/MCPCard.tsx
+++ b/src/components/mcps/MCPCard.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { syncMCPToTools } from "@/lib/api/sync";
 import { SyncDialog } from "@/components/sync";
 import { Button } from "@/components/ui/button";
+import { OpenPathButton } from "@/components/ui/open-path-button";
 import { HealthBadge } from "./HealthBadge";
 import { MCPIcon } from "./MCPIcon";
 import { TestHealthDialog } from "./TestHealthDialog";
@@ -156,6 +157,12 @@ export function MCPCard({ mcp }: MCPCardProps) {
               <Activity className="mr-2 h-3.5 w-3.5" />
               Test
             </Button>
+            <OpenPathButton
+              path={mcp.path}
+              variant="outline"
+              size="sm"
+              label="Open Config"
+            />
 
             {missingTools.length > 0 && (
               <Button

--- a/src/components/skills/SkillViewer.tsx
+++ b/src/components/skills/SkillViewer.tsx
@@ -7,6 +7,7 @@ import { TokenBadge } from "@/components/context";
 import { SyncDialog } from "@/components/sync";
 import { MaturityBadge } from "./MaturityBadge";
 import { Button } from "@/components/ui/button";
+import { OpenPathButton } from "@/components/ui/open-path-button";
 
 const ALL_TOOLS: SourceTool[] = ["claude", "codex", "gemini"];
 
@@ -87,22 +88,29 @@ export function SkillViewer({ skill, onClose }: SkillViewerProps) {
 
         {/* Footer */}
         <div className="flex items-center justify-between border-t border-border px-4 py-2">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
             <FolderOpen className="h-3.5 w-3.5 shrink-0" />
             <span className="truncate font-mono" title={skill.path}>
               {skill.path}
             </span>
           </div>
-          {missingTools.length > 0 && (
-            <Button
+          <div className="flex items-center gap-2">
+            <OpenPathButton
+              path={skill.path}
               variant="outline"
               size="sm"
-              onClick={() => setShowSync(true)}
-            >
-              <Share2 className="mr-1.5 h-3.5 w-3.5" />
-              Sync to Other Tools
-            </Button>
-          )}
+            />
+            {missingTools.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowSync(true)}
+              >
+                <Share2 className="mr-1.5 h-3.5 w-3.5" />
+                Sync to Other Tools
+              </Button>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/components/ui/open-path-button.tsx
+++ b/src/components/ui/open-path-button.tsx
@@ -1,0 +1,47 @@
+import { useState, type MouseEvent } from "react";
+import { FolderOpen } from "lucide-react";
+import { revealInFileManager } from "@/lib/api/system";
+import { Button, type ButtonProps } from "./button";
+
+interface OpenPathButtonProps extends Omit<ButtonProps, "onClick"> {
+  path: string;
+  label?: string;
+}
+
+export function OpenPathButton({
+  path,
+  label = "Open Location",
+  disabled,
+  title,
+  ...buttonProps
+}: OpenPathButtonProps) {
+  const [opening, setOpening] = useState(false);
+
+  const handleOpen = async (
+    event: MouseEvent<HTMLButtonElement>
+  ) => {
+    event.stopPropagation();
+    if (!path) return;
+
+    try {
+      setOpening(true);
+      await revealInFileManager(path);
+    } catch (error) {
+      console.error("Failed to reveal path:", path, error);
+    } finally {
+      setOpening(false);
+    }
+  };
+
+  return (
+    <Button
+      {...buttonProps}
+      disabled={disabled || opening}
+      onClick={handleOpen}
+      title={title ?? path}
+    >
+      <FolderOpen className="mr-1.5 h-3.5 w-3.5" />
+      {opening ? "Opening..." : label}
+    </Button>
+  );
+}

--- a/src/lib/api/system.ts
+++ b/src/lib/api/system.ts
@@ -1,0 +1,11 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Reveal a file or folder in the system file manager.
+ * - macOS: Finder
+ * - Windows: Explorer
+ * - Linux: default file manager
+ */
+export async function revealInFileManager(path: string): Promise<void> {
+  return invoke("reveal_in_file_manager", { path });
+}

--- a/src/pages/Context.tsx
+++ b/src/pages/Context.tsx
@@ -272,7 +272,7 @@ export function Context() {
               <div className="space-y-2 text-xs text-muted-foreground">
                 <div>
                   <span className="font-medium text-amber-500">Rules</span>{" "}
-                  — Full content loaded on every message. Always-on cost.
+                  — Full content loaded on every message. Always-on cost. Scoped rules only load when the agent works on a matching file.
                 </div>
                 <div>
                   <span className="font-medium text-purple-500">Skills</span>{" "}
@@ -297,7 +297,7 @@ export function Context() {
                 <div>
                   <span className="font-medium text-foreground">Idle tokens</span>{" "}
                   — Consumed on every single message you send, even when the item is not being used.
-                  Rules and MCP tool definitions are always idle cost.
+                  User and project rules are always idle cost. Scoped rules only apply when a matching file is active. MCP tool definitions are always idle cost.
                 </div>
                 <div>
                   <span className="font-medium text-foreground">Active tokens</span>{" "}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -208,6 +208,7 @@ export interface HookItem {
   matcher: string | null;
   command: string;
   actionType: string;
+  path: string;
 }
 
 export interface HookScanResult {


### PR DESCRIPTION
## Summary

Add OpenPathButton component allowing users to open config files and paths directly in their native file manager. Implements a cross-platform `reveal_in_file_manager` Tauri command with automatic fallback to parent directories for missing files. Also clarifies rules scope terminology in the Context page to better explain how scoped rules work.

## Changes

- **System Commands**: New `reveal_in_file_manager` command with platform-specific implementations (macOS Finder, Windows Explorer, Linux xdg-open)
- **HookItem**: Added `path` field to track source config file locations
- **OpenPathButton Component**: Reusable button for opening paths with loading state and error handling
- **UI Updates**: Integrated OpenPathButton in RuleViewer, MCPCard, SkillViewer, and HooksSection
- **Documentation**: Clarified scoped rules behavior in token cost explanations

## Test Plan

- Click "Open Config" or folder buttons in various viewers to verify file manager opens correctly
- Test with non-existent files to verify fallback to parent directory works
- Verify path is displayed correctly in hover tooltips across all components
- Test on different platforms (macOS/Windows/Linux) if available