### PR TITLE
Add Learn page with educational concept cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Skills } from "@/pages/Skills";
 import { Rules } from "@/pages/Rules";
 import { Hooks } from "@/pages/Hooks";
 import { Context } from "@/pages/Context";
+import { Learn } from "@/pages/Learn";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 function App() {
@@ -22,6 +23,8 @@ function App() {
         return <Hooks />;
       case "context":
         return <Context />;
+      case "learn":
+        return <Learn />;
       default:
         return <MCPs />;
     }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,7 @@ const tabLabels: Record<string, string> = {
   rules: "Rules",
   hooks: "Hooks",
   context: "Context",
+  learn: "Learn",
 };
 
 export function Header() {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   FileText,
   Anchor,
   BarChart3,
+  BookOpen,
   FolderOpen,
   ChevronDown,
   GitBranch,
@@ -295,6 +296,21 @@ export function Sidebar() {
             );
           })}
         </ul>
+
+        <div className="my-2 border-t border-sidebar-border" />
+
+        <button
+          onClick={() => setActiveTab("learn")}
+          className={cn(
+            "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+            activeTab === "learn"
+              ? "bg-sidebar-accent text-sidebar-accent-foreground"
+              : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+          )}
+        >
+          <BookOpen className="h-4 w-4" />
+          Learn
+        </button>
       </nav>
 
       {/* Version */}

--- a/src/components/learn/ConceptCard.tsx
+++ b/src/components/learn/ConceptCard.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import { ArrowRight, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+
+interface ConceptCardProps {
+  icon: LucideIcon;
+  iconColorClass: string;
+  iconBgClass: string;
+  title: string;
+  description: string;
+  details: string[];
+  pageTab?: "mcps" | "skills" | "rules" | "hooks" | "context";
+  pageLabel?: string;
+}
+
+export function ConceptCard({
+  icon: Icon,
+  iconColorClass,
+  iconBgClass,
+  title,
+  description,
+  details,
+  pageTab,
+  pageLabel,
+}: ConceptCardProps) {
+  const [open, setOpen] = useState(false);
+  const { setActiveTab } = useWorkspaceStore();
+
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center gap-3 p-4 text-left transition-colors hover:bg-muted/30"
+      >
+        <div
+          className={cn(
+            "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+            iconBgClass
+          )}
+        >
+          <Icon className={cn("h-4.5 w-4.5", iconColorClass)} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="font-semibold">{title}</h3>
+          <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
+        </div>
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-180"
+          )}
+        />
+      </button>
+
+      {open && (
+        <div className="border-t border-border px-4 pb-4 pt-3">
+          <ul className="space-y-1.5">
+            {details.map((detail, i) => (
+              <li
+                key={i}
+                className="flex items-start gap-2 text-xs text-muted-foreground"
+              >
+                <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-muted-foreground/40" />
+                <span>{detail}</span>
+              </li>
+            ))}
+          </ul>
+
+          {pageTab && pageLabel && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setActiveTab(pageTab);
+              }}
+              className="mt-3 flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+            >
+              {pageLabel}
+              <ArrowRight className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/learn/EcosystemTable.tsx
+++ b/src/components/learn/EcosystemTable.tsx
@@ -1,0 +1,78 @@
+const tools = [
+  {
+    name: "Claude Code",
+    color: "text-orange-500",
+    format: "JSON",
+    mcpConfig: "~/.claude.json",
+    skillsDir: "~/.claude/skills/",
+    rulesFile: "CLAUDE.md",
+  },
+  {
+    name: "Codex CLI",
+    color: "text-green-500",
+    format: "TOML",
+    mcpConfig: "~/.codex/config.toml",
+    skillsDir: "~/.codex/skills/",
+    rulesFile: "AGENTS.md",
+  },
+  {
+    name: "Gemini CLI",
+    color: "text-blue-500",
+    format: "JSON",
+    mcpConfig: "~/.gemini/settings.json",
+    skillsDir: "~/.gemini/skills/",
+    rulesFile: "GEMINI.md",
+  },
+];
+
+export function EcosystemTable() {
+  return (
+    <div className="rounded-lg border border-border bg-card p-5">
+      <h3 className="mb-1 font-semibold">The Ecosystem</h3>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Three AI coding tools share the same concepts but store configuration in
+        different files and formats.
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-border text-left text-muted-foreground">
+              <th className="pb-2 pr-4 font-medium">Tool</th>
+              <th className="pb-2 pr-4 font-medium">Format</th>
+              <th className="pb-2 pr-4 font-medium">MCP Config</th>
+              <th className="pb-2 pr-4 font-medium">Skills</th>
+              <th className="pb-2 font-medium">Rules</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {tools.map((tool) => (
+              <tr key={tool.name}>
+                <td className={`py-2.5 pr-4 font-medium ${tool.color}`}>
+                  {tool.name}
+                </td>
+                <td className="py-2.5 pr-4 text-muted-foreground">
+                  {tool.format}
+                </td>
+                <td className="py-2.5 pr-4 font-mono text-muted-foreground">
+                  {tool.mcpConfig}
+                </td>
+                <td className="py-2.5 pr-4 font-mono text-muted-foreground">
+                  {tool.skillsDir}
+                </td>
+                <td className="py-2.5 font-mono text-muted-foreground">
+                  {tool.rulesFile}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mt-3 text-[11px] text-muted-foreground/70">
+        Project-level configs (like <span className="font-mono">.mcp.json</span>{" "}
+        for MCPs) live in the workspace root and apply only to that project.
+      </p>
+    </div>
+  );
+}

--- a/src/components/learn/index.ts
+++ b/src/components/learn/index.ts
@@ -1,0 +1,2 @@
+export { ConceptCard } from "./ConceptCard";
+export { EcosystemTable } from "./EcosystemTable";

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -1,0 +1,127 @@
+import {
+  Server,
+  Sparkles,
+  FileText,
+  Anchor,
+  BarChart3,
+  Layers,
+} from "lucide-react";
+import { ConceptCard, EcosystemTable } from "@/components/learn";
+
+export function Learn() {
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <h2 className="text-2xl font-semibold">Learn</h2>
+        <p className="mt-1 text-muted-foreground">
+          A quick reference to the concepts Loadout helps you manage
+        </p>
+      </div>
+
+      {/* Building Blocks */}
+      <div className="mb-8">
+        <h3 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Building Blocks
+        </h3>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <ConceptCard
+            icon={Server}
+            iconColorClass="text-cyan-500"
+            iconBgClass="bg-cyan-500/10"
+            title="MCPs"
+            description="Model Context Protocol servers give AI agents new capabilities — like browsing the web, querying databases, or managing files."
+            details={[
+              "stdio type: runs a local process via a shell command (e.g., npx, uvx)",
+              "http type: connects to a remote URL endpoint",
+              "Configured in tool-specific config files (see ecosystem table below)",
+              "Tool definitions consume context tokens on every message",
+            ]}
+            pageTab="mcps"
+            pageLabel="Go to MCPs page"
+          />
+
+          <ConceptCard
+            icon={Sparkles}
+            iconColorClass="text-purple-500"
+            iconBgClass="bg-purple-500/10"
+            title="Skills"
+            description="Reusable instruction sets stored as SKILL.md files. Invoked as /slash-commands to teach the AI how to do specific tasks."
+            details={[
+              "Only the description is loaded at idle (low token cost)",
+              "Full content loads only when the skill is invoked (active cost)",
+              "Defined in .claude/skills/<name>/SKILL.md (path varies by tool)",
+              "Priority order varies by tool — check each tool's docs for shadowing behavior",
+            ]}
+            pageTab="skills"
+            pageLabel="Go to Skills page"
+          />
+
+          <ConceptCard
+            icon={FileText}
+            iconColorClass="text-amber-500"
+            iconBgClass="bg-amber-500/10"
+            title="Rules"
+            description="System instruction files injected into the AI's context on every message. They shape how the agent behaves in your project."
+            details={[
+              "Always-loaded rules: full content in context on every turn",
+              "Scoped rules: only loaded when the agent works on matching files",
+              "Each tool uses its own file: CLAUDE.md, AGENTS.md, or GEMINI.md",
+              "High token cost — keep them concise",
+            ]}
+            pageTab="rules"
+            pageLabel="Go to Rules page"
+          />
+
+          <ConceptCard
+            icon={Anchor}
+            iconColorClass="text-muted-foreground"
+            iconBgClass="bg-muted"
+            title="Hooks"
+            description="Shell commands that run automatically at lifecycle events — before or after a tool call, when a session starts or ends."
+            details={[
+              "Supported in Claude Code and Gemini CLI",
+              "Events: PreToolUse, PostToolUse, SessionStart, SessionEnd, and more",
+              "Can be scoped to specific tools (e.g., only before file writes)",
+              "Codex CLI has only a basic notify mechanism",
+            ]}
+            pageTab="hooks"
+            pageLabel="Go to Hooks page"
+          />
+
+          <ConceptCard
+            icon={BarChart3}
+            iconColorClass="text-primary"
+            iconBgClass="bg-primary/10"
+            title="Context Window"
+            description="The 200K-token budget shared by all your rules, skills, and MCP tool definitions. Understanding it helps you optimize your setup."
+            details={[
+              "Idle tokens: consumed on every message, even when items aren't used",
+              "Active tokens: consumed only when you invoke a skill",
+              "Rules and MCP definitions are always idle cost",
+              "Claude's Tool Search can reduce MCP idle cost dynamically",
+            ]}
+            pageTab="context"
+            pageLabel="Go to Context page"
+          />
+
+          <ConceptCard
+            icon={Layers}
+            iconColorClass="text-emerald-500"
+            iconBgClass="bg-emerald-500/10"
+            title="Scope"
+            description="Config items are either user-level (global, applies to all projects) or project-level (specific to a workspace)."
+            details={[
+              "User-level: stored in your home directory, always active",
+              "Project-level: stored in the workspace root, only active there",
+              "Shadowing: a project-level item overrides a user-level item with the same name",
+              "Select a workspace in the sidebar to see both scopes",
+            ]}
+          />
+        </div>
+      </div>
+
+      {/* Ecosystem */}
+      <EcosystemTable />
+    </div>
+  );
+}

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -5,10 +5,10 @@ import type { WorkspaceInfo } from "@/lib/api/workspace";
 interface WorkspaceState {
   current: WorkspaceInfo | null;
   recent: string[];
-  activeTab: "mcps" | "skills" | "rules" | "hooks" | "context";
+  activeTab: "mcps" | "skills" | "rules" | "hooks" | "context" | "learn";
   setCurrent: (workspace: WorkspaceInfo | null) => void;
   addRecent: (path: string) => void;
-  setActiveTab: (tab: "mcps" | "skills" | "rules" | "hooks" | "context") => void;
+  setActiveTab: (tab: "mcps" | "skills" | "rules" | "hooks" | "context" | "learn") => void;
 }
 
 const MAX_RECENT = 5;


### PR DESCRIPTION
## Summary

Add a new Learn page accessible from the sidebar that teaches users about Loadout's core concepts. The page features six collapsible concept cards (MCPs, Skills, Rules, Hooks, Context Window, Scope) plus an ecosystem comparison table showing how these concepts are configured across Claude Code, Codex CLI, and Gemini CLI. All educational claims have been fact-checked against official documentation.

## Key Changes

- New Learn page (`src/pages/Learn.tsx`) with collapsible concept cards
- ConceptCard component for clean, reusable educational UI
- EcosystemTable comparing config file locations across three tools
- Learn nav item in sidebar (BookOpen icon) separated by divider from data pages
- Type-safe implementation with "learn" added to activeTab union type

## Design

Cards show only title + one-liner by default, expanding on click to reveal details and navigation links to relevant pages. Clean, non-overwhelming learning experience that integrates with existing Loadout navigation patterns.