### PR TITLE
Add project-level hooks/MCPs and home dashboard

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -11,6 +11,6 @@ pub fn scan_rules(workspace_path: Option<String>) -> Result<PromptScanResult, St
 
 /// Scan hook configurations from Claude and Gemini settings
 #[tauri::command]
-pub fn scan_hooks() -> Result<HookScanResult, String> {
-    scan_all_hooks()
+pub fn scan_hooks(workspace_path: Option<String>) -> Result<HookScanResult, String> {
+    scan_all_hooks(workspace_path.as_deref())
 }

--- a/src-tauri/src/scanners/hooks.rs
+++ b/src-tauri/src/scanners/hooks.rs
@@ -2,9 +2,17 @@
 //!
 //! Parses hook configurations from settings.json files and normalizes
 //! them into a unified view. Codex only has a basic `notify` mechanism.
+//!
+//! Both Claude Code and Gemini CLI support hooks at two levels:
+//! - User-level: ~/.claude/settings[.local].json / ~/.gemini/settings.json
+//! - Project-level: <workspace>/.claude/settings[.local].json / <workspace>/.gemini/settings.json
+//!
+//! Claude Code has both settings.json (shared/git-tracked) and settings.local.json
+//! (personal/gitignored). Both can contain hooks, and they're additive.
 
-use crate::parsers::{parse_claude_settings, parse_gemini_config};
+use crate::parsers::{parse_claude_settings, parse_gemini_config, ClaudeSettings, GeminiConfig};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 /// Source tool for a hook
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -14,12 +22,22 @@ pub enum HookSourceTool {
     Gemini,
 }
 
+/// Scope level for a hook
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum HookScope {
+    User,
+    Project,
+}
+
 /// A normalized hook configuration item
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HookItem {
     /// Which tool this hook belongs to
     pub source_tool: HookSourceTool,
+    /// Scope (user-level or project-level)
+    pub scope: HookScope,
     /// Event name (e.g., "PreToolUse", "BeforeTool")
     pub event: String,
     /// Matcher pattern (e.g., "Bash|Write")
@@ -37,50 +55,20 @@ pub struct HookItem {
 #[serde(rename_all = "camelCase")]
 pub struct HookScanResult {
     pub hooks: Vec<HookItem>,
-    /// Whether Gemini hooks experiment flag is enabled
+    /// Whether Gemini hooks experiment flag is enabled (user-level)
     pub gemini_hooks_enabled: bool,
 }
 
-/// Scan all hook configurations
-pub fn scan_all_hooks() -> Result<HookScanResult, String> {
-    let home_dir = dirs::home_dir().ok_or("Could not determine home directory")?;
-    let mut hooks: Vec<HookItem> = Vec::new();
-
-    // Scan Claude Code hooks from ~/.claude/settings.json
-    let claude_settings_path = home_dir.join(".claude").join("settings.json");
-    if let Ok(settings) = parse_claude_settings(&claude_settings_path) {
-        for (event, matchers) in &settings.hooks {
-            for matcher_entry in matchers {
-                for action in &matcher_entry.hooks {
-                    if let Some(cmd) = &action.command {
-                        hooks.push(HookItem {
-                            source_tool: HookSourceTool::Claude,
-                            event: event.clone(),
-                            matcher: matcher_entry.matcher.clone(),
-                            command: cmd.clone(),
-                            action_type: action
-                                .action_type
-                                .clone()
-                                .unwrap_or_else(|| "command".to_string()),
-                            path: claude_settings_path.to_string_lossy().to_string(),
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    // Scan Gemini CLI hooks from ~/.gemini/settings.json
-    let gemini_settings_path = home_dir.join(".gemini").join("settings.json");
-    let gemini_config = parse_gemini_config(&gemini_settings_path).unwrap_or_default();
-    let gemini_hooks_enabled = gemini_config.experiments.enable_hooks;
-
-    for (event, matchers) in &gemini_config.hooks {
+/// Extract hooks from a parsed Claude settings file
+fn collect_claude_hooks(settings: &ClaudeSettings, path: &Path, scope: HookScope) -> Vec<HookItem> {
+    let mut hooks = Vec::new();
+    for (event, matchers) in &settings.hooks {
         for matcher_entry in matchers {
             for action in &matcher_entry.hooks {
                 if let Some(cmd) = &action.command {
                     hooks.push(HookItem {
-                        source_tool: HookSourceTool::Gemini,
+                        source_tool: HookSourceTool::Claude,
+                        scope,
                         event: event.clone(),
                         matcher: matcher_entry.matcher.clone(),
                         command: cmd.clone(),
@@ -88,17 +76,92 @@ pub fn scan_all_hooks() -> Result<HookScanResult, String> {
                             .action_type
                             .clone()
                             .unwrap_or_else(|| "command".to_string()),
-                        path: gemini_settings_path.to_string_lossy().to_string(),
+                        path: path.to_string_lossy().to_string(),
                     });
                 }
             }
         }
     }
+    hooks
+}
 
-    // Sort by tool then event
+/// Extract hooks from a parsed Gemini config file
+fn collect_gemini_hooks(config: &GeminiConfig, path: &Path, scope: HookScope) -> Vec<HookItem> {
+    let mut hooks = Vec::new();
+    for (event, matchers) in &config.hooks {
+        for matcher_entry in matchers {
+            for action in &matcher_entry.hooks {
+                if let Some(cmd) = &action.command {
+                    hooks.push(HookItem {
+                        source_tool: HookSourceTool::Gemini,
+                        scope,
+                        event: event.clone(),
+                        matcher: matcher_entry.matcher.clone(),
+                        command: cmd.clone(),
+                        action_type: action
+                            .action_type
+                            .clone()
+                            .unwrap_or_else(|| "command".to_string()),
+                        path: path.to_string_lossy().to_string(),
+                    });
+                }
+            }
+        }
+    }
+    hooks
+}
+
+/// Scan all hook configurations (user-level + optional project-level)
+pub fn scan_all_hooks(workspace_path: Option<&str>) -> Result<HookScanResult, String> {
+    let home_dir = dirs::home_dir().ok_or("Could not determine home directory")?;
+    let mut hooks: Vec<HookItem> = Vec::new();
+
+    // --- User-level hooks ---
+    // Claude Code stores hooks in both settings.json (shared) and settings.local.json (personal).
+    // Both are scanned — hooks are additive across files.
+
+    for filename in &["settings.json", "settings.local.json"] {
+        let claude_user_path = home_dir.join(".claude").join(filename);
+        if let Ok(settings) = parse_claude_settings(&claude_user_path) {
+            hooks.extend(collect_claude_hooks(&settings, &claude_user_path, HookScope::User));
+        }
+    }
+
+    // Gemini CLI: ~/.gemini/settings.json
+    let gemini_user_path = home_dir.join(".gemini").join("settings.json");
+    let gemini_user_config = parse_gemini_config(&gemini_user_path).unwrap_or_default();
+    let gemini_hooks_enabled = gemini_user_config.experiments.enable_hooks;
+    hooks.extend(collect_gemini_hooks(&gemini_user_config, &gemini_user_path, HookScope::User));
+
+    // --- Project-level hooks ---
+
+    if let Some(ws_path) = workspace_path {
+        let ws = Path::new(ws_path);
+
+        // Claude Code: <workspace>/.claude/settings.json and settings.local.json
+        for filename in &["settings.json", "settings.local.json"] {
+            let claude_project_path = ws.join(".claude").join(filename);
+            if claude_project_path.exists() {
+                if let Ok(settings) = parse_claude_settings(&claude_project_path) {
+                    hooks.extend(collect_claude_hooks(&settings, &claude_project_path, HookScope::Project));
+                }
+            }
+        }
+
+        // Gemini CLI: <workspace>/.gemini/settings.json
+        let gemini_project_path = ws.join(".gemini").join("settings.json");
+        if gemini_project_path.exists() {
+            if let Ok(config) = parse_gemini_config(&gemini_project_path) {
+                hooks.extend(collect_gemini_hooks(&config, &gemini_project_path, HookScope::Project));
+            }
+        }
+    }
+
+    // Sort by scope (user first), then tool, then event
     hooks.sort_by(|a, b| {
-        format!("{:?}", a.source_tool)
-            .cmp(&format!("{:?}", b.source_tool))
+        format!("{:?}", a.scope)
+            .cmp(&format!("{:?}", b.scope))
+            .then_with(|| format!("{:?}", a.source_tool).cmp(&format!("{:?}", b.source_tool)))
             .then_with(|| a.event.cmp(&b.event))
     });
 
@@ -116,6 +179,7 @@ mod tests {
     fn test_hook_item_serialization() {
         let hook = HookItem {
             source_tool: HookSourceTool::Claude,
+            scope: HookScope::User,
             event: "PreToolUse".to_string(),
             matcher: Some("Bash|Write".to_string()),
             command: "/path/to/script.sh".to_string(),
@@ -126,5 +190,22 @@ mod tests {
         let json = serde_json::to_string(&hook).unwrap();
         assert!(json.contains("PreToolUse"));
         assert!(json.contains("sourceTool"));
+        assert!(json.contains("\"scope\":\"user\""));
+    }
+
+    #[test]
+    fn test_hook_scope_serialization() {
+        let project_hook = HookItem {
+            source_tool: HookSourceTool::Gemini,
+            scope: HookScope::Project,
+            event: "BeforeTool".to_string(),
+            matcher: None,
+            command: "echo test".to_string(),
+            action_type: "command".to_string(),
+            path: "/project/.gemini/settings.json".to_string(),
+        };
+
+        let json = serde_json::to_string(&project_hook).unwrap();
+        assert!(json.contains("\"scope\":\"project\""));
     }
 }

--- a/src-tauri/src/scanners/mcps.rs
+++ b/src-tauri/src/scanners/mcps.rs
@@ -114,9 +114,11 @@ pub fn scan_all_mcps(workspace_path: Option<&str>) -> Result<Vec<MCPItem>, Strin
         }
     }
 
-    // Project-level: $PROJECT_ROOT/.mcp.json
+    // Project-level: $PROJECT_ROOT/.mcp.json (Claude Code)
     if let Some(ws_path) = workspace_path {
-        let project_mcp_path = PathBuf::from(ws_path).join(".mcp.json");
+        let ws = PathBuf::from(ws_path);
+
+        let project_mcp_path = ws.join(".mcp.json");
         if let Ok(config) = parse_claude_config(&project_mcp_path) {
             for (name, server) in config.mcp_servers {
                 let mcp_type = if server.mcp_type == "http" {
@@ -136,6 +138,53 @@ pub fn scan_all_mcps(workspace_path: Option<&str>) -> Result<Vec<MCPItem>, Strin
                     scope: Scope::Project,
                     path: project_mcp_path.to_string_lossy().to_string(),
                 });
+            }
+        }
+
+        // Project-level: $PROJECT_ROOT/.codex/config.toml (Codex CLI)
+        let codex_project_path = ws.join(".codex").join("config.toml");
+        if codex_project_path.exists() {
+            if let Ok(config) = parse_codex_config(&codex_project_path) {
+                for (name, server) in config.mcp_servers {
+                    entries.push(RawMCPEntry {
+                        name,
+                        mcp_type: MCPType::Stdio, // Codex only supports stdio
+                        command: Some(server.command),
+                        args: server.args,
+                        url: None,
+                        env: server.env,
+                        headers: HashMap::new(),
+                        source_tool: SourceTool::Codex,
+                        scope: Scope::Project,
+                        path: codex_project_path.to_string_lossy().to_string(),
+                    });
+                }
+            }
+        }
+
+        // Project-level: $PROJECT_ROOT/.gemini/settings.json (Gemini CLI)
+        let gemini_project_path = ws.join(".gemini").join("settings.json");
+        if gemini_project_path.exists() {
+            if let Ok(config) = parse_gemini_config(&gemini_project_path) {
+                for (name, server) in config.mcp_servers {
+                    let mcp_type = if server.mcp_type == "http" {
+                        MCPType::Http
+                    } else {
+                        MCPType::Stdio
+                    };
+                    entries.push(RawMCPEntry {
+                        name,
+                        mcp_type,
+                        command: server.command,
+                        args: server.args,
+                        url: server.url,
+                        env: server.env,
+                        headers: server.headers,
+                        source_tool: SourceTool::Gemini,
+                        scope: Scope::Project,
+                        path: gemini_project_path.to_string_lossy().to_string(),
+                    });
+                }
             }
         }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Sidebar } from "@/components/Sidebar";
 import { Header } from "@/components/Header";
+import { Home } from "@/pages/Home";
 import { MCPs } from "@/pages/MCPs";
 import { Skills } from "@/pages/Skills";
 import { Rules } from "@/pages/Rules";
@@ -13,6 +14,8 @@ function App() {
 
   const renderPage = () => {
     switch (activeTab) {
+      case "home":
+        return <Home />;
       case "mcps":
         return <MCPs />;
       case "skills":
@@ -26,7 +29,7 @@ function App() {
       case "learn":
         return <Learn />;
       default:
-        return <MCPs />;
+        return <Home />;
     }
   };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { FolderOpen, GitBranch } from "lucide-react";
 
 const tabLabels: Record<string, string> = {
+  home: "Home",
   mcps: "MCPs",
   skills: "Skills",
   rules: "Rules",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Home,
   Server,
   Sparkles,
   FileText,
@@ -13,7 +14,7 @@ import {
   X,
 } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { cn } from "@/lib/utils";
+import { cn, isRealWorkspace } from "@/lib/utils";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { getWorkspaceInfo, discoverWorkspaces } from "@/lib/api/workspace";
 import { useState, useEffect, useRef } from "react";
@@ -21,6 +22,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { DiscoveredWorkspace } from "@/types";
 
 const navItems = [
+  { id: "home" as const, label: "Home", icon: Home },
   { id: "mcps" as const, label: "MCPs", icon: Server },
   { id: "skills" as const, label: "Skills", icon: Sparkles },
   { id: "rules" as const, label: "Rules", icon: FileText },
@@ -136,12 +138,14 @@ export function Sidebar() {
   };
 
   const filteredWorkspaces =
-    discovery?.workspaces.filter(
-      (ws) =>
-        !filter ||
-        ws.name.toLowerCase().includes(filter.toLowerCase()) ||
-        ws.path.toLowerCase().includes(filter.toLowerCase())
-    ) ?? [];
+    discovery?.workspaces
+      .filter(isRealWorkspace)
+      .filter(
+        (ws) =>
+          !filter ||
+          ws.name.toLowerCase().includes(filter.toLowerCase()) ||
+          ws.path.toLowerCase().includes(filter.toLowerCase())
+      ) ?? [];
 
   return (
     <aside className="flex h-full w-[200px] flex-col border-r border-sidebar-border bg-sidebar">

--- a/src/components/config/HooksSection.tsx
+++ b/src/components/config/HooksSection.tsx
@@ -73,6 +73,9 @@ export function HooksSection({ hooks, geminiHooksEnabled }: HooksSectionProps) {
                     Tool
                   </th>
                   <th className="px-3 py-2 text-left font-medium text-muted-foreground">
+                    Scope
+                  </th>
+                  <th className="px-3 py-2 text-left font-medium text-muted-foreground">
                     Event
                   </th>
                   <th className="px-3 py-2 text-left font-medium text-muted-foreground">
@@ -105,6 +108,18 @@ export function HooksSection({ hooks, geminiHooksEnabled }: HooksSectionProps) {
                         )}
                       >
                         {hook.sourceTool}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={cn(
+                          "inline-flex rounded-md border px-1.5 py-0.5 text-[10px] font-medium",
+                          hook.scope === "project"
+                            ? "border-purple-500/20 bg-purple-500/10 text-purple-600"
+                            : "border-border bg-muted/50 text-muted-foreground"
+                        )}
+                      >
+                        {hook.scope}
                       </span>
                     </td>
                     <td className="px-3 py-2 font-mono text-xs">
@@ -189,7 +204,11 @@ export function HooksSection({ hooks, geminiHooksEnabled }: HooksSectionProps) {
           <p className="text-xs text-muted-foreground">
             {claudeHooks.length} Claude hook
             {claudeHooks.length !== 1 ? "s" : ""}, {geminiHooks.length} Gemini
-            hook{geminiHooks.length !== 1 ? "s" : ""}. Codex only supports{" "}
+            hook{geminiHooks.length !== 1 ? "s" : ""}
+            {hooks.some((h) => h.scope === "project") && (
+              <> ({hooks.filter((h) => h.scope === "project").length} project-level)</>
+            )}
+            . Codex only supports{" "}
             <code className="rounded bg-muted px-1">notify</code> (limited).
           </p>
         </>

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -11,8 +11,12 @@ export async function scanRules(
 }
 
 /**
- * Scan hook configurations from Claude and Gemini settings
+ * Scan hook configurations from Claude and Gemini settings.
+ * Pass workspacePath to include project-level hooks from
+ * <workspace>/.claude/settings.json and <workspace>/.gemini/settings.json.
  */
-export async function scanHooks(): Promise<HookScanResult> {
-  return invoke<HookScanResult>("scan_hooks");
+export async function scanHooks(
+  workspacePath?: string
+): Promise<HookScanResult> {
+  return invoke<HookScanResult>("scan_hooks", { workspacePath });
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,18 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/** User-level config directory names that aren't real project workspaces */
+const USER_CONFIG_DIRS = new Set([".claude", ".codex", ".gemini"]);
+
+/**
+ * Filter out user-level config directories from discovered workspaces.
+ * Directories like ~/.claude, ~/.codex, ~/.gemini contain AI tool configs
+ * but aren't real project workspaces.
+ */
+export function isRealWorkspace(ws: { name: string }): boolean {
+  return !USER_CONFIG_DIRS.has(ws.name);
+}
+
 /**
  * Format a token count for display.
  * e.g., 340 → "~340", 2100 → "~2.1K", 15000 → "~15K"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,563 @@
+import { useMemo, useState } from "react";
+import {
+  Server,
+  Sparkles,
+  FileText,
+  Anchor,
+  RefreshCw,
+  AlertCircle,
+  ChevronRight,
+  FolderOpen,
+  GitBranch,
+} from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { cn, isRealWorkspace } from "@/lib/utils";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
+import { scanMCPs } from "@/lib/api/mcps";
+import { scanSkills } from "@/lib/api/skills";
+import { scanRules, scanHooks } from "@/lib/api/config";
+import { discoverWorkspaces } from "@/lib/api/workspace";
+import type {
+  SourceTool,
+  MCPItem,
+  SkillItem,
+  PromptFile,
+  HookItem,
+  DiscoveredWorkspace,
+} from "@/types";
+
+const TOOLS: SourceTool[] = ["claude", "codex", "gemini"];
+
+const toolDotColors: Record<SourceTool, string> = {
+  claude: "bg-orange-500",
+  codex: "bg-green-500",
+  gemini: "bg-blue-500",
+};
+
+const toolTextColors: Record<SourceTool, string> = {
+  claude: "text-orange-500",
+  codex: "text-green-500",
+  gemini: "text-blue-500",
+};
+
+const toolLabels: Record<SourceTool, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  gemini: "Gemini",
+};
+
+// ---------------------------------------------------------------------------
+// Stat Card
+// ---------------------------------------------------------------------------
+
+interface StatCardProps {
+  icon: React.ElementType;
+  label: string;
+  count: number;
+  isLoading: boolean;
+  toolBreakdown: { tool: SourceTool; count: number }[];
+  onClick: () => void;
+}
+
+function StatCard({
+  icon: Icon,
+  label,
+  count,
+  isLoading,
+  toolBreakdown,
+  onClick,
+}: StatCardProps) {
+  const nonZeroTools = toolBreakdown.filter((t) => t.count > 0);
+
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "group flex flex-col rounded-lg border border-border bg-card p-5 text-left transition-all",
+        "hover:border-primary/30 hover:ring-1 hover:ring-primary/20"
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted">
+          <Icon className="h-4.5 w-4.5 text-muted-foreground" />
+        </div>
+        <ChevronRight className="h-4 w-4 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+      </div>
+
+      <div className="mt-4">
+        {isLoading ? (
+          <RefreshCw className="h-4 w-4 animate-spin text-muted-foreground" />
+        ) : (
+          <span className="text-3xl font-semibold tracking-tight">
+            {count}
+          </span>
+        )}
+      </div>
+
+      <p className="mt-1 text-sm text-muted-foreground">{label}</p>
+
+      {!isLoading && nonZeroTools.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {nonZeroTools.map(({ tool, count: toolCount }) => (
+            <span
+              key={tool}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground"
+            >
+              <span
+                className={cn("h-2 w-2 rounded-full", toolDotColors[tool])}
+              />
+              {toolCount}
+            </span>
+          ))}
+        </div>
+      )}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tool Coverage Row
+// ---------------------------------------------------------------------------
+
+interface ToolRowProps {
+  tool: SourceTool;
+  mcpCount: number;
+  skillCount: number;
+  ruleCount: number;
+  hookCount: number;
+}
+
+function ToolRow({
+  tool,
+  mcpCount,
+  skillCount,
+  ruleCount,
+  hookCount,
+}: ToolRowProps) {
+  const total = mcpCount + skillCount + ruleCount + hookCount;
+  if (total === 0) return null;
+
+  const segments = [
+    { label: "MCP", count: mcpCount },
+    { label: "skill", count: skillCount },
+    { label: "rule", count: ruleCount },
+    { label: "hook", count: hookCount },
+  ].filter((s) => s.count > 0);
+
+  return (
+    <div className="flex items-center gap-3 rounded-md px-3 py-2.5 transition-colors hover:bg-muted/50">
+      <span
+        className={cn(
+          "h-2.5 w-2.5 shrink-0 rounded-full",
+          toolDotColors[tool]
+        )}
+      />
+      <span className={cn("w-16 text-sm font-medium", toolTextColors[tool])}>
+        {toolLabels[tool]}
+      </span>
+      <span className="text-sm text-muted-foreground">
+        {segments
+          .map((s) => `${s.count} ${s.label}${s.count !== 1 ? "s" : ""}`)
+          .join(" \u00b7 ")}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Workspace Signal Helpers
+// ---------------------------------------------------------------------------
+
+function wsHasMCPs(ws: DiscoveredWorkspace): boolean {
+  // Only .mcp.json indicates project-level MCP servers.
+  // hasClaudeConfig/hasCodexConfig/hasGeminiConfig are too broad —
+  // they fire for .claude/ dirs and CLAUDE.md files which don't mean MCPs.
+  return ws.signals.hasMcpJson;
+}
+
+function wsHasSkills(ws: DiscoveredWorkspace): boolean {
+  return ws.signals.hasClaudeSkills || ws.signals.hasCodexSkills || ws.signals.hasGeminiSkills;
+}
+
+function wsHasRules(ws: DiscoveredWorkspace): boolean {
+  return ws.signals.hasClaudePrompt || ws.signals.hasCodexPrompt || ws.signals.hasGeminiPrompt;
+}
+
+function countWorkspacesWithMCPs(workspaces: DiscoveredWorkspace[]): number {
+  return workspaces.filter(wsHasMCPs).length;
+}
+
+function countWorkspacesWithSkills(workspaces: DiscoveredWorkspace[]): number {
+  return workspaces.filter(wsHasSkills).length;
+}
+
+function countWorkspacesWithRules(workspaces: DiscoveredWorkspace[]): number {
+  return workspaces.filter(wsHasRules).length;
+}
+
+/** Workspace has at least one meaningful project-level config (not just a .claude/ session dir) */
+function wsHasAnyConfig(ws: DiscoveredWorkspace): boolean {
+  return wsHasMCPs(ws) || wsHasSkills(ws) || wsHasRules(ws);
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+function computeToolBreakdown(
+  mcps: MCPItem[],
+  skills: SkillItem[],
+  rules: PromptFile[],
+  hooks: HookItem[],
+  tool: SourceTool
+) {
+  return {
+    mcpCount: mcps.filter((m) => m.configuredIn.includes(tool)).length,
+    skillCount: skills.filter((s) => s.sourceTool === tool).length,
+    ruleCount: rules.filter((r) => r.sourceTool === tool).length,
+    hookCount: hooks.filter((h) => h.sourceTool === tool).length,
+  };
+}
+
+export function Home() {
+  const { setActiveTab } = useWorkspaceStore();
+
+  // Always scan user-level only (no workspace dependency)
+  const {
+    data: mcps,
+    isLoading: mcpsLoading,
+    error: mcpsError,
+  } = useQuery({
+    queryKey: ["mcps", null],
+    queryFn: () => scanMCPs(undefined),
+  });
+
+  const {
+    data: skillsResult,
+    isLoading: skillsLoading,
+    error: skillsError,
+  } = useQuery({
+    queryKey: ["skills", null],
+    queryFn: () => scanSkills(undefined),
+  });
+
+  const {
+    data: rulesResult,
+    isLoading: rulesLoading,
+    error: rulesError,
+  } = useQuery({
+    queryKey: ["rules", null],
+    queryFn: () => scanRules(undefined),
+  });
+
+  const {
+    data: hooksResult,
+    isLoading: hooksLoading,
+    error: hooksError,
+  } = useQuery({
+    queryKey: ["hooks", null],
+    queryFn: () => scanHooks(undefined),
+  });
+
+  // Reuse the same discovery query as the sidebar (shared cache)
+  const {
+    data: discovery,
+    isLoading: discoveryLoading,
+  } = useQuery({
+    queryKey: ["discover-workspaces"],
+    queryFn: () => discoverWorkspaces(4),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const mcpsList = mcps ?? [];
+  const skills = skillsResult?.skills ?? [];
+  const rules = (rulesResult?.prompts ?? []).filter((r) => r.exists);
+  const hooks = hooksResult?.hooks ?? [];
+  const workspaces = (discovery?.workspaces ?? []).filter(isRealWorkspace);
+
+  const error = mcpsError || skillsError || rulesError || hooksError;
+
+  // Tool breakdown for stat cards
+  const mcpToolBreakdown = useMemo(
+    () =>
+      TOOLS.map((tool) => ({
+        tool,
+        count: mcpsList.filter((m) => m.configuredIn.includes(tool)).length,
+      })),
+    [mcpsList]
+  );
+
+  const skillToolBreakdown = useMemo(
+    () =>
+      TOOLS.map((tool) => ({
+        tool,
+        count: skills.filter((s) => s.sourceTool === tool).length,
+      })),
+    [skills]
+  );
+
+  const ruleToolBreakdown = useMemo(
+    () =>
+      TOOLS.map((tool) => ({
+        tool,
+        count: rules.filter((r) => r.sourceTool === tool).length,
+      })),
+    [rules]
+  );
+
+  const hookToolBreakdown = useMemo(
+    () =>
+      TOOLS.map((tool) => ({
+        tool,
+        count: hooks.filter((h) => h.sourceTool === tool).length,
+      })),
+    [hooks]
+  );
+
+  // Per-tool coverage
+  const toolCoverage = useMemo(
+    () =>
+      TOOLS.map((tool) => ({
+        tool,
+        ...computeToolBreakdown(mcpsList, skills, rules, hooks, tool),
+      })),
+    [mcpsList, skills, rules, hooks]
+  );
+
+  const allItemsLoaded =
+    !mcpsLoading && !skillsLoading && !rulesLoading && !hooksLoading;
+  const hasAnyData =
+    mcpsList.length > 0 ||
+    skills.length > 0 ||
+    rules.length > 0 ||
+    hooks.length > 0;
+
+  // Workspace filter state
+  const [wsFilter, setWsFilter] = useState<"all" | "mcps" | "rules" | "skills">("all");
+
+  // Workspace signal counts
+  const wsWithMCPs = useMemo(
+    () => countWorkspacesWithMCPs(workspaces),
+    [workspaces]
+  );
+  const wsWithSkills = useMemo(
+    () => countWorkspacesWithSkills(workspaces),
+    [workspaces]
+  );
+  const wsWithRules = useMemo(
+    () => countWorkspacesWithRules(workspaces),
+    [workspaces]
+  );
+
+  // Only count workspaces with meaningful configs (MCPs, rules, or skills)
+  const meaningfulWorkspaces = useMemo(
+    () => workspaces.filter(wsHasAnyConfig),
+    [workspaces]
+  );
+
+  const filteredWorkspaces = useMemo(() => {
+    if (wsFilter === "mcps") return workspaces.filter(wsHasMCPs);
+    if (wsFilter === "rules") return workspaces.filter(wsHasRules);
+    if (wsFilter === "skills") return workspaces.filter(wsHasSkills);
+    return meaningfulWorkspaces;
+  }, [workspaces, meaningfulWorkspaces, wsFilter]);
+
+  return (
+    <div className="p-6">
+      {/* Header */}
+      <div className="mb-6">
+        <h2 className="text-2xl font-semibold">Your AI Setup</h2>
+        <p className="mt-1 text-muted-foreground">
+          Global configuration across your AI coding tools
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-500/20 bg-red-500/5 p-4">
+          <div className="flex items-center gap-2 text-red-600">
+            <AlertCircle className="h-5 w-5" />
+            <span className="font-medium">Failed to load some data</span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {error instanceof Error ? error.message : "Unknown error occurred"}
+          </p>
+        </div>
+      )}
+
+      {/* Stat cards — user-level counts */}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          icon={Server}
+          label="MCP Servers"
+          count={mcpsList.length}
+          isLoading={mcpsLoading}
+          toolBreakdown={mcpToolBreakdown}
+          onClick={() => setActiveTab("mcps")}
+        />
+        <StatCard
+          icon={Sparkles}
+          label="Skills"
+          count={skills.length}
+          isLoading={skillsLoading}
+          toolBreakdown={skillToolBreakdown}
+          onClick={() => setActiveTab("skills")}
+        />
+        <StatCard
+          icon={FileText}
+          label="Rules"
+          count={rules.length}
+          isLoading={rulesLoading}
+          toolBreakdown={ruleToolBreakdown}
+          onClick={() => setActiveTab("rules")}
+        />
+        <StatCard
+          icon={Anchor}
+          label="Hooks"
+          count={hooks.length}
+          isLoading={hooksLoading}
+          toolBreakdown={hookToolBreakdown}
+          onClick={() => setActiveTab("hooks")}
+        />
+      </div>
+
+      {/* Tool coverage */}
+      {allItemsLoaded && hasAnyData && (
+        <div className="mt-6 rounded-lg border border-border bg-card p-4">
+          <h3 className="mb-2 text-sm font-medium text-muted-foreground">
+            Tool Coverage
+          </h3>
+          <div className="space-y-0.5">
+            {toolCoverage.map(
+              ({ tool, mcpCount, skillCount, ruleCount, hookCount }) => (
+                <ToolRow
+                  key={tool}
+                  tool={tool}
+                  mcpCount={mcpCount}
+                  skillCount={skillCount}
+                  ruleCount={ruleCount}
+                  hookCount={hookCount}
+                />
+              )
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Workspaces — discovery-based */}
+      {discoveryLoading ? (
+        <div className="mt-6 rounded-lg border border-border bg-card p-4">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <RefreshCw className="h-4 w-4 animate-spin" />
+            Scanning workspaces...
+          </div>
+        </div>
+      ) : meaningfulWorkspaces.length > 0 ? (
+        <div className="mt-6 rounded-lg border border-border bg-card p-4">
+          <h3 className="mb-1 text-sm font-medium text-muted-foreground">
+            Across Your Projects
+          </h3>
+          <p className="mb-3 text-xs text-muted-foreground">
+            {meaningfulWorkspaces.length} workspace{meaningfulWorkspaces.length !== 1 ? "s" : ""}{" "}
+            with project-level AI configs
+          </p>
+
+          {/* Filter cards — clickable toggles */}
+          <div className="grid grid-cols-3 gap-3">
+            {wsWithMCPs > 0 && (
+              <button
+                onClick={() => setWsFilter(wsFilter === "mcps" ? "all" : "mcps")}
+                className={cn(
+                  "rounded-md border px-3 py-2.5 text-left transition-colors",
+                  wsFilter === "mcps"
+                    ? "border-primary/40 bg-primary/5 ring-1 ring-primary/20"
+                    : "border-border bg-muted/30 hover:border-border hover:bg-muted/50"
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <Server className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-sm font-medium">{wsWithMCPs}</span>
+                </div>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  with MCP configs
+                </p>
+              </button>
+            )}
+            {wsWithRules > 0 && (
+              <button
+                onClick={() => setWsFilter(wsFilter === "rules" ? "all" : "rules")}
+                className={cn(
+                  "rounded-md border px-3 py-2.5 text-left transition-colors",
+                  wsFilter === "rules"
+                    ? "border-primary/40 bg-primary/5 ring-1 ring-primary/20"
+                    : "border-border bg-muted/30 hover:border-border hover:bg-muted/50"
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <FileText className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-sm font-medium">{wsWithRules}</span>
+                </div>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  with rules
+                </p>
+              </button>
+            )}
+            {wsWithSkills > 0 && (
+              <button
+                onClick={() => setWsFilter(wsFilter === "skills" ? "all" : "skills")}
+                className={cn(
+                  "rounded-md border px-3 py-2.5 text-left transition-colors",
+                  wsFilter === "skills"
+                    ? "border-primary/40 bg-primary/5 ring-1 ring-primary/20"
+                    : "border-border bg-muted/30 hover:border-border hover:bg-muted/50"
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-sm font-medium">{wsWithSkills}</span>
+                </div>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  with skills
+                </p>
+              </button>
+            )}
+          </div>
+
+          {/* All workspaces (filtered) */}
+          <div className="mt-3 space-y-0.5">
+            {filteredWorkspaces.map((ws) => (
+              <div
+                key={ws.path}
+                className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm hover:bg-muted/50"
+              >
+                <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 truncate font-medium text-xs">
+                  {ws.name}
+                </span>
+                {ws.isGitRepo && (
+                  <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+                )}
+                <div className="ml-auto flex items-center gap-1">
+                  {(ws.signals.hasClaudeConfig ||
+                    ws.signals.hasClaudePrompt ||
+                    ws.signals.hasClaudeSkills) && (
+                    <span className="h-2 w-2 rounded-full bg-orange-500" title="Claude" />
+                  )}
+                  {(ws.signals.hasCodexConfig ||
+                    ws.signals.hasCodexPrompt ||
+                    ws.signals.hasCodexSkills) && (
+                    <span className="h-2 w-2 rounded-full bg-green-500" title="Codex" />
+                  )}
+                  {(ws.signals.hasGeminiConfig ||
+                    ws.signals.hasGeminiPrompt ||
+                    ws.signals.hasGeminiSkills) && (
+                    <span className="h-2 w-2 rounded-full bg-blue-500" title="Gemini" />
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/pages/Hooks.tsx
+++ b/src/pages/Hooks.tsx
@@ -6,9 +6,12 @@ import { HooksSection } from "@/components/config";
 import { SearchBar } from "@/components/filters";
 import { Button } from "@/components/ui/button";
 import { useInfiniteList } from "@/hooks/useInfiniteList";
+import { useWorkspaceStore } from "@/stores/workspaceStore";
 
 export function Hooks() {
   const [searchQuery, setSearchQuery] = useState("");
+  const workspace = useWorkspaceStore((s) => s.current);
+  const workspacePath = workspace?.path ?? undefined;
 
   const {
     data: result,
@@ -17,8 +20,8 @@ export function Hooks() {
     refetch,
     isRefetching,
   } = useQuery({
-    queryKey: ["hooks"],
-    queryFn: () => scanHooks(),
+    queryKey: ["hooks", workspacePath ?? null],
+    queryFn: () => scanHooks(workspacePath),
   });
 
   const filteredHooks = useMemo(() => {

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -5,10 +5,10 @@ import type { WorkspaceInfo } from "@/lib/api/workspace";
 interface WorkspaceState {
   current: WorkspaceInfo | null;
   recent: string[];
-  activeTab: "mcps" | "skills" | "rules" | "hooks" | "context" | "learn";
+  activeTab: "home" | "mcps" | "skills" | "rules" | "hooks" | "context" | "learn";
   setCurrent: (workspace: WorkspaceInfo | null) => void;
   addRecent: (path: string) => void;
-  setActiveTab: (tab: "mcps" | "skills" | "rules" | "hooks" | "context" | "learn") => void;
+  setActiveTab: (tab: "home" | "mcps" | "skills" | "rules" | "hooks" | "context" | "learn") => void;
 }
 
 const MAX_RECENT = 5;
@@ -18,7 +18,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     (set) => ({
       current: null,
       recent: [],
-      activeTab: "mcps", // Default to MCPs per spec
+      activeTab: "home",
       setCurrent: (workspace) =>
         set((state) => {
           if (workspace) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -199,11 +199,14 @@ export interface PromptScanResult {
 
 export type HookSourceTool = "claude" | "gemini";
 
+export type HookScope = "user" | "project";
+
 /**
  * A normalized hook configuration item
  */
 export interface HookItem {
   sourceTool: HookSourceTool;
+  scope: HookScope;
   event: string;
   matcher: string | null;
   command: string;


### PR DESCRIPTION
## Summary
- Support project-level hooks from `.claude/settings.json` and `.gemini/settings.json`
- Extend MCP scanner for project-level Codex and Gemini configs
- Add HookScope enum to distinguish user vs project-level configurations
- Create Home page as the new default landing point
- Filter out user config directories from workspace discovery list

## Test plan
- [ ] Verify project-level hooks appear in the Hooks page when workspace is selected
- [ ] Verify scope column correctly displays "user" and "project" labels
- [ ] Verify Home page loads as the default landing page
- [ ] Verify user config directories (.claude, .codex, .gemini) don't appear in workspace list
- [ ] Verify existing user-level hooks and MCPs still work correctly