### PR TITLE
Redesign sync dialog UX & enable HTTP MCPs for Codex

### DIFF
--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -93,12 +93,6 @@ fn is_supported_mcp_type(mcp_type: &str) -> bool {
     matches!(mcp_type, "stdio" | "http")
 }
 
-fn ensure_tool_compatible_with_mcp(tool: &str, mcp_type: &str) -> Result<(), String> {
-    if tool == "codex" && mcp_type == "http" {
-        return Err("Codex CLI only supports stdio MCP servers".to_string());
-    }
-    Ok(())
-}
 
 /// Preview the generated config for each selected tool without writing
 #[tauri::command]
@@ -113,8 +107,6 @@ pub fn preview_mcp_configs(request: AddMCPRequest) -> Result<PreviewResult, Stri
     let mut configs = Vec::new();
 
     for tool in &request.target_tools {
-        ensure_tool_compatible_with_mcp(tool, &mcp.mcp_type)?;
-
         match tool.as_str() {
             "claude" => configs.push(PreviewConfig {
                 tool: "claude".to_string(),
@@ -177,11 +169,6 @@ pub fn add_mcp_to_tools(request: AddMCPRequest) -> Result<WriteResult, String> {
     let mut errors = Vec::new();
 
     for tool in &request.target_tools {
-        if let Err(e) = ensure_tool_compatible_with_mcp(tool, &mcp.mcp_type) {
-            errors.push(format!("{}: {}", tool, e));
-            continue;
-        }
-
         let path = match mcp_config_path(tool) {
             Ok(p) => p,
             Err(e) => {
@@ -257,11 +244,16 @@ fn read_mcp_from_source(
             for path in candidate_paths {
                 let config = parse_codex_config(&path)?;
                 if let Some(server) = config.mcp_servers.get(name) {
+                    let mcp_type = if server.url.is_some() {
+                        "http"
+                    } else {
+                        "stdio"
+                    };
                     return Ok(MCPServerInput {
-                        mcp_type: "stdio".to_string(),
-                        command: Some(server.command.clone()),
+                        mcp_type: mcp_type.to_string(),
+                        command: server.command.clone(),
                         args: server.args.clone(),
-                        url: None,
+                        url: server.url.clone(),
                         env: server.env.clone(),
                     });
                 }
@@ -320,11 +312,6 @@ pub fn sync_mcp_to_tools(request: SyncMCPRequest) -> Result<WriteResult, String>
     let mut errors = Vec::new();
 
     for tool in &request.target_tools {
-        if let Err(e) = ensure_tool_compatible_with_mcp(tool, &mcp.mcp_type) {
-            errors.push(format!("{}: {}", tool, e));
-            continue;
-        }
-
         let path = match mcp_config_path(tool) {
             Ok(p) => p,
             Err(e) => {
@@ -394,21 +381,6 @@ mod tests {
     use tempfile::NamedTempFile;
 
     #[test]
-    fn test_codex_rejects_http_mcp() {
-        assert!(ensure_tool_compatible_with_mcp("codex", "http").is_err());
-    }
-
-    #[test]
-    fn test_codex_accepts_stdio_mcp() {
-        assert!(ensure_tool_compatible_with_mcp("codex", "stdio").is_ok());
-    }
-
-    #[test]
-    fn test_claude_accepts_http_mcp() {
-        assert!(ensure_tool_compatible_with_mcp("claude", "http").is_ok());
-    }
-
-    #[test]
     fn test_read_mcp_from_claude_source_path() {
         let file = NamedTempFile::new().unwrap();
         fs::write(
@@ -438,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn test_preview_rejects_http_for_codex() {
+    fn test_preview_http_for_codex() {
         let request = AddMCPRequest {
             name: "http-server".to_string(),
             mcp_type: "http".to_string(),
@@ -449,7 +421,9 @@ mod tests {
             target_tools: vec!["codex".to_string()],
         };
 
-        let err = preview_mcp_configs(request).unwrap_err();
-        assert!(err.contains("Codex CLI only supports stdio"));
+        let result = preview_mcp_configs(request).unwrap();
+        assert_eq!(result.configs.len(), 1);
+        assert_eq!(result.configs[0].tool, "codex");
+        assert!(result.configs[0].content.contains("url"));
     }
 }

--- a/src-tauri/src/converters/mcp_format.rs
+++ b/src-tauri/src/converters/mcp_format.rs
@@ -54,12 +54,18 @@ pub fn to_codex_toml_preview(name: &str, mcp: &MCPServerInput) -> String {
     let mut lines = Vec::new();
     lines.push(format!("[mcp_servers.{}]", name));
 
-    if let Some(cmd) = &mcp.command {
-        lines.push(format!("command = \"{}\"", cmd));
-    }
-    if !mcp.args.is_empty() {
-        let args: Vec<String> = mcp.args.iter().map(|a| format!("\"{}\"", a)).collect();
-        lines.push(format!("args = [{}]", args.join(", ")));
+    if mcp.mcp_type == "http" {
+        if let Some(url) = &mcp.url {
+            lines.push(format!("url = \"{}\"", url));
+        }
+    } else {
+        if let Some(cmd) = &mcp.command {
+            lines.push(format!("command = \"{}\"", cmd));
+        }
+        if !mcp.args.is_empty() {
+            let args: Vec<String> = mcp.args.iter().map(|a| format!("\"{}\"", a)).collect();
+            lines.push(format!("args = [{}]", args.join(", ")));
+        }
     }
 
     if !mcp.env.is_empty() {

--- a/src-tauri/src/parsers/toml_config.rs
+++ b/src-tauri/src/parsers/toml_config.rs
@@ -7,11 +7,15 @@ use std::path::Path;
 
 /// MCP server configuration from TOML (Codex format)
 /// Note: Codex uses `mcp_servers` (underscore) not `mcpServers` (camelCase)
+/// Supports both stdio (command + args) and HTTP (url) transports.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TomlMCPServer {
-    pub command: String,
+    /// Command to run (required for stdio, absent for HTTP)
+    pub command: Option<String>,
     #[serde(default)]
     pub args: Vec<String>,
+    /// URL endpoint (required for HTTP, absent for stdio)
+    pub url: Option<String>,
     #[serde(default)]
     pub env: HashMap<String, String>,
 }
@@ -78,7 +82,7 @@ GITHUB_TOKEN = "test"
         let config = parse_codex_config(file.path()).unwrap();
         assert!(config.mcp_servers.contains_key("github"));
         let github = config.mcp_servers.get("github").unwrap();
-        assert_eq!(github.command, "npx");
+        assert_eq!(github.command.as_deref(), Some("npx"));
         assert_eq!(github.args, vec!["-y", "@github/mcp-server"]);
     }
 

--- a/src-tauri/src/scanners/mcps.rs
+++ b/src-tauri/src/scanners/mcps.rs
@@ -146,12 +146,17 @@ pub fn scan_all_mcps(workspace_path: Option<&str>) -> Result<Vec<MCPItem>, Strin
         if codex_project_path.exists() {
             if let Ok(config) = parse_codex_config(&codex_project_path) {
                 for (name, server) in config.mcp_servers {
+                    let mcp_type = if server.url.is_some() {
+                        MCPType::Http
+                    } else {
+                        MCPType::Stdio
+                    };
                     entries.push(RawMCPEntry {
                         name,
-                        mcp_type: MCPType::Stdio, // Codex only supports stdio
-                        command: Some(server.command),
+                        mcp_type,
+                        command: server.command,
                         args: server.args,
-                        url: None,
+                        url: server.url,
                         env: server.env,
                         headers: HashMap::new(),
                         source_tool: SourceTool::Codex,
@@ -194,12 +199,17 @@ pub fn scan_all_mcps(workspace_path: Option<&str>) -> Result<Vec<MCPItem>, Strin
     let codex_config_path = home_dir.join(".codex").join("config.toml");
     if let Ok(config) = parse_codex_config(&codex_config_path) {
         for (name, server) in config.mcp_servers {
+            let mcp_type = if server.url.is_some() {
+                MCPType::Http
+            } else {
+                MCPType::Stdio
+            };
             entries.push(RawMCPEntry {
                 name,
-                mcp_type: MCPType::Stdio, // Codex only supports stdio
-                command: Some(server.command),
+                mcp_type,
+                command: server.command,
                 args: server.args,
-                url: None,
+                url: server.url,
                 env: server.env,
                 headers: HashMap::new(),
                 source_tool: SourceTool::Codex,

--- a/src-tauri/src/writers/mcp_writer.rs
+++ b/src-tauri/src/writers/mcp_writer.rs
@@ -44,17 +44,6 @@ pub fn write_mcp_to_claude(name: &str, mcp: &MCPServerInput, path: &Path) -> Res
 /// Uses toml_edit to preserve comments and formatting.
 /// Creates the file with a minimal structure if it doesn't exist.
 pub fn write_mcp_to_codex(name: &str, mcp: &MCPServerInput, path: &Path) -> Result<(), String> {
-    if mcp.mcp_type == "http" {
-        return Err("Codex CLI does not support HTTP MCP servers".to_string());
-    }
-
-    let command = mcp
-        .command
-        .as_deref()
-        .map(str::trim)
-        .filter(|cmd| !cmd.is_empty())
-        .ok_or_else(|| "Codex MCP entries require a command".to_string())?;
-
     let mut doc: DocumentMut = if path.exists() {
         let content = fs::read_to_string(path)
             .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
@@ -72,14 +61,33 @@ pub fn write_mcp_to_codex(name: &str, mcp: &MCPServerInput, path: &Path) -> Resu
 
     // Create the server entry as a table
     let mut server_table = toml_edit::Table::new();
-    server_table["command"] = toml_edit::value(command);
 
-    if !mcp.args.is_empty() {
-        let mut args_array = toml_edit::Array::new();
-        for arg in &mcp.args {
-            args_array.push(arg.as_str());
+    if mcp.mcp_type == "http" {
+        // HTTP MCP: use url field
+        let url = mcp
+            .url
+            .as_deref()
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .ok_or_else(|| "HTTP MCP entries require a URL".to_string())?;
+        server_table["url"] = toml_edit::value(url);
+    } else {
+        // stdio MCP: use command + args
+        let command = mcp
+            .command
+            .as_deref()
+            .map(str::trim)
+            .filter(|cmd| !cmd.is_empty())
+            .ok_or_else(|| "Codex MCP entries require a command".to_string())?;
+        server_table["command"] = toml_edit::value(command);
+
+        if !mcp.args.is_empty() {
+            let mut args_array = toml_edit::Array::new();
+            for arg in &mcp.args {
+                args_array.push(arg.as_str());
+            }
+            server_table["args"] = toml_edit::value(args_array);
         }
-        server_table["args"] = toml_edit::value(args_array);
     }
 
     if !mcp.env.is_empty() {
@@ -249,12 +257,17 @@ mod tests {
     }
 
     #[test]
-    fn test_write_http_mcp_to_codex_is_rejected() {
+    fn test_write_http_mcp_to_codex() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("config.toml");
 
-        let err = write_mcp_to_codex("linear", &http_mcp(), &path).unwrap_err();
-        assert!(err.contains("does not support HTTP"));
+        write_mcp_to_codex("linear", &http_mcp(), &path).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("[mcp_servers.linear]"));
+        assert!(content.contains("url = \"https://mcp.linear.app/mcp\""));
+        // HTTP MCPs should not have command/args
+        assert!(!content.contains("command"));
     }
 
     #[test]

--- a/src/components/mcps/MCPCard.tsx
+++ b/src/components/mcps/MCPCard.tsx
@@ -25,10 +25,7 @@ export function MCPCard({ mcp }: MCPCardProps) {
   const envKeys = Object.keys(mcp.env);
   const hasEnv = envKeys.length > 0;
   const isHttp = mcp.mcpType === "http";
-  const syncEligibleTools = isHttp
-    ? ALL_TOOLS.filter((tool) => tool !== "codex")
-    : ALL_TOOLS;
-  const missingTools = syncEligibleTools.filter(
+  const missingTools = ALL_TOOLS.filter(
     (tool) => !mcp.configuredIn.includes(tool)
   );
 
@@ -191,7 +188,7 @@ export function MCPCard({ mcp }: MCPCardProps) {
           type="mcp"
           name={mcp.name}
           existingTools={mcp.configuredIn}
-          availableTools={syncEligibleTools}
+          availableTools={ALL_TOOLS}
           onSync={(targetTools) =>
             syncMCPToTools({
               name: mcp.name,

--- a/src/components/sync/AddMCPDialog.tsx
+++ b/src/components/sync/AddMCPDialog.tsx
@@ -32,10 +32,8 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
   // Preview state
   const [previews, setPreviews] = useState<PreviewConfig[]>([]);
   const isHttpMCP = mcpType === "http";
-  const disabledTools: SourceTool[] = isHttpMCP ? ["codex"] : [];
-  const effectiveTargetTools = isHttpMCP
-    ? targetTools.filter((tool) => tool !== "codex")
-    : targetTools;
+  const disabledTools: SourceTool[] = [];
+  const effectiveTargetTools = targetTools;
 
   const buildRequest = (): AddMCPRequest => ({
     name: name.trim(),
@@ -254,10 +252,6 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
                 placeholder="e.g., https://mcp.linear.app/mcp"
                 className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
               />
-              <p className="text-xs text-muted-foreground">
-                Codex CLI supports only stdio MCP servers, so it is disabled
-                for HTTP MCPs.
-              </p>
             </div>
           )}
 
@@ -304,11 +298,7 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
           {/* Tool Selector */}
           <ToolSelector
             selectedTools={effectiveTargetTools}
-            onToolsChange={(tools) =>
-              setTargetTools(
-                isHttpMCP ? tools.filter((tool) => tool !== "codex") : tools
-              )
-            }
+            onToolsChange={setTargetTools}
             type="mcp"
             disabledTools={disabledTools}
             disabledReason="Codex CLI only supports stdio MCP servers"

--- a/src/components/sync/SyncDialog.tsx
+++ b/src/components/sync/SyncDialog.tsx
@@ -99,18 +99,18 @@ export function SyncDialog({
           )}
 
           <p className="text-sm">
-            Sync <span className="font-semibold">{name}</span> to additional
-            tools:
+            Sync <span className="font-semibold">{name}</span> to other tools:
           </p>
 
           <ToolSelector
             selectedTools={effectiveTargetTools}
             onToolsChange={setTargetTools}
             type={type}
+            existingTools={existingTools}
             disabledTools={disabledTools}
             disabledReason={
               type === "mcp"
-                ? "This tool does not support this MCP type"
+                ? "stdio only"
                 : undefined
             }
           />

--- a/src/components/sync/ToolSelector.tsx
+++ b/src/components/sync/ToolSelector.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Check } from "lucide-react";
 import type { SourceTool } from "@/types";
 import { cn } from "@/lib/utils";
 import { ToolLogo } from "@/components/ToolLogo";
@@ -7,6 +7,7 @@ interface ToolSelectorProps {
   selectedTools: SourceTool[];
   onToolsChange: (tools: SourceTool[]) => void;
   type?: "mcp" | "skill";
+  existingTools?: SourceTool[];
   disabledTools?: SourceTool[];
   disabledReason?: string;
 }
@@ -33,6 +34,7 @@ export function ToolSelector({
   selectedTools,
   onToolsChange,
   type = "mcp",
+  existingTools = [],
   disabledTools = [],
   disabledReason,
 }: ToolSelectorProps) {
@@ -48,47 +50,83 @@ export function ToolSelector({
     }
   };
 
+  const installedTools = tools.filter(({ id }) => existingTools.includes(id));
+  const targetTools = tools.filter(
+    ({ id }) => !existingTools.includes(id)
+  );
+
   return (
-    <div className="space-y-2">
-      <label className="text-sm font-medium">Target Tools</label>
-      <div className="flex flex-wrap gap-3">
-        {tools.map(({ id, label, color }) => {
-          const isDisabled = disabledTools.includes(id);
-          return (
-            <label
-              key={id}
-              title={isDisabled ? disabledReason : undefined}
-              className={cn(
-                "flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
-                isDisabled
-                  ? "cursor-not-allowed opacity-50"
-                  : "cursor-pointer",
-                selectedTools.includes(id)
-                  ? "border-primary bg-primary/5"
-                  : "border-border hover:bg-muted/50"
-              )}
-            >
-              <input
-                type="checkbox"
-                checked={selectedTools.includes(id)}
-                onChange={() => toggle(id)}
-                disabled={isDisabled}
-                className={cn("h-4 w-4 rounded", color)}
-              />
-              <ToolLogo tool={id} size={14} />
-              {label}
-            </label>
-          );
-        })}
-      </div>
-      {type === "skill" && selectedTools.includes("gemini") && (
-        <div className="flex items-center gap-2 rounded-md bg-yellow-500/10 px-3 py-2 text-xs text-yellow-700">
-          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          Skills are experimental in Gemini CLI (requires{" "}
-          <code className="rounded bg-yellow-500/20 px-1">
-            experiments.agentSkills: true
-          </code>
-          )
+    <div className="space-y-4">
+      {/* Already installed section */}
+      {installedTools.length > 0 && (
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-muted-foreground">
+            Already installed in
+          </label>
+          <div className="flex flex-wrap gap-3">
+            {installedTools.map(({ id, label }) => (
+              <div
+                key={id}
+                className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
+              >
+                <Check className="h-4 w-4 text-green-500" />
+                <ToolLogo tool={id} size={14} />
+                {label}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Sync targets section */}
+      {targetTools.length > 0 && (
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Sync to</label>
+          <div className="flex flex-wrap gap-3">
+            {targetTools.map(({ id, label, color }) => {
+              const isDisabled = disabledTools.includes(id);
+              return (
+                <label
+                  key={id}
+                  title={isDisabled ? disabledReason : undefined}
+                  className={cn(
+                    "flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors",
+                    isDisabled
+                      ? "cursor-not-allowed opacity-50"
+                      : "cursor-pointer",
+                    selectedTools.includes(id)
+                      ? "border-primary bg-primary/5"
+                      : "border-border hover:bg-muted/50"
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedTools.includes(id)}
+                    onChange={() => toggle(id)}
+                    disabled={isDisabled}
+                    className={cn("h-4 w-4 rounded", color)}
+                  />
+                  <ToolLogo tool={id} size={14} />
+                  {label}
+                  {isDisabled && disabledReason && (
+                    <span className="ml-1 text-xs text-muted-foreground">
+                      ({disabledReason})
+                    </span>
+                  )}
+                </label>
+              );
+            })}
+          </div>
+          {type === "skill" && selectedTools.includes("gemini") && (
+            <div className="flex items-center gap-2 rounded-md bg-yellow-500/10 px-3 py-2 text-xs text-yellow-700">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+              Skills are experimental in Gemini CLI (requires{" "}
+              <code className="rounded bg-yellow-500/20 px-1">
+                experiments.agentSkills: true
+              </code>
+              )
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- **Sync dialog UX**: Split interface into read-only "Already installed in" section and interactive "Sync to" section for clarity about which tools already have the MCP vs which can be targets
- **HTTP MCP support for Codex**: Codex CLI now supports streamable HTTP MCPs. Removed outdated restriction and implemented full support: updated TOML parser/writer, scanner type detection, and removed frontend exclusions

## Changes
Backend:
- TomlMCPServer now supports optional `url` field for HTTP MCPs (command is also optional)
- Scanner auto-detects HTTP type from url presence instead of hardcoding stdio
- MCP writer generates correct TOML for both stdio and HTTP MCPs
- Removed `ensure_tool_compatible_with_mcp` compatibility check

Frontend:
- ToolSelector now shows two sections with better UX clarity
- Removed Codex/HTTP exclusion logic from MCPCard and AddMCPDialog
- Updated SyncDialog to pass existingTools and use concise disabled message

## Testing
- All 73 Rust unit tests pass
- TypeScript type-checking passes
- New tests added for HTTP MCP preview and writing to Codex