### PR TITLE
Make context window size configurable per tool

### DIFF
--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -10,6 +10,7 @@ export interface ToolConfig {
   textClass: string;     // text-{color}-500 etc.
   badgeClass: string;    // bg-{color}/10 text-{color} border-{color}/20
   filterActiveClass: string;
+  contextWindow: number; // Model context window size in tokens
 }
 
 export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
@@ -19,6 +20,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-orange-500",
     badgeClass: "bg-orange-500/10 text-orange-600 border-orange-500/20",
     filterActiveClass: "bg-orange-500/15 text-orange-600 border-orange-500/30",
+    contextWindow: 200_000,
   },
   codex: {
     label: "Codex",
@@ -26,6 +28,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-green-500",
     badgeClass: "bg-green-500/10 text-green-600 border-green-500/20",
     filterActiveClass: "bg-green-500/15 text-green-600 border-green-500/30",
+    contextWindow: 200_000,
   },
   gemini: {
     label: "Gemini",
@@ -33,6 +36,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-blue-500",
     badgeClass: "bg-blue-500/10 text-blue-600 border-blue-500/20",
     filterActiveClass: "bg-blue-500/15 text-blue-600 border-blue-500/30",
+    contextWindow: 1_000_000,
   },
   cursor: {
     label: "Cursor",
@@ -40,6 +44,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-purple-500",
     badgeClass: "bg-purple-500/10 text-purple-600 border-purple-500/20",
     filterActiveClass: "bg-purple-500/15 text-purple-600 border-purple-500/30",
+    contextWindow: 200_000,
   },
   copilot: {
     label: "Copilot",
@@ -47,6 +52,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-sky-500",
     badgeClass: "bg-sky-500/10 text-sky-600 border-sky-500/20",
     filterActiveClass: "bg-sky-500/15 text-sky-600 border-sky-500/30",
+    contextWindow: 200_000,
   },
   windsurf: {
     label: "Windsurf",
@@ -54,6 +60,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-teal-500",
     badgeClass: "bg-teal-500/10 text-teal-600 border-teal-500/20",
     filterActiveClass: "bg-teal-500/15 text-teal-600 border-teal-500/30",
+    contextWindow: 200_000,
   },
   roo: {
     label: "Roo",
@@ -61,6 +68,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-rose-500",
     badgeClass: "bg-rose-500/10 text-rose-600 border-rose-500/20",
     filterActiveClass: "bg-rose-500/15 text-rose-600 border-rose-500/30",
+    contextWindow: 200_000,
   },
   cline: {
     label: "Cline",
@@ -68,6 +76,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-amber-500",
     badgeClass: "bg-amber-500/10 text-amber-600 border-amber-500/20",
     filterActiveClass: "bg-amber-500/15 text-amber-600 border-amber-500/30",
+    contextWindow: 200_000,
   },
   kilo: {
     label: "Kilo",
@@ -75,6 +84,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-lime-500",
     badgeClass: "bg-lime-500/10 text-lime-600 border-lime-500/20",
     filterActiveClass: "bg-lime-500/15 text-lime-600 border-lime-500/30",
+    contextWindow: 200_000,
   },
   opencode: {
     label: "OpenCode",
@@ -82,6 +92,7 @@ export const TOOL_CONFIG: Record<SourceTool, ToolConfig> = {
     textClass: "text-indigo-500",
     badgeClass: "bg-indigo-500/10 text-indigo-600 border-indigo-500/20",
     filterActiveClass: "bg-indigo-500/15 text-indigo-600 border-indigo-500/30",
+    contextWindow: 200_000,
   },
 };
 
@@ -96,4 +107,13 @@ export function toolLabel(tool: SourceTool): string {
 /** Get text color class for a tool */
 export function toolTextColor(tool: SourceTool): string {
   return TOOL_CONFIG[tool]?.textClass ?? "text-muted-foreground";
+}
+
+/** Default context window used when no specific tool is selected */
+export const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+/** Get context window size for a tool (or default when null) */
+export function toolContextWindow(tool: SourceTool | null): number {
+  if (!tool) return DEFAULT_CONTEXT_WINDOW;
+  return TOOL_CONFIG[tool]?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
 }

--- a/src/lib/api/context.ts
+++ b/src/lib/api/context.ts
@@ -1,7 +1,5 @@
 import type { PromptFile, SkillItem, MCPItem, MCPToolsResult, SourceTool } from "@/types";
-
-/** Default context window size for Claude models */
-export const CONTEXT_WINDOW_LIMIT = 200_000;
+import { toolContextWindow } from "@/config/tools";
 
 export interface ContextSummary {
   /** Total tokens consumed at idle (rules + skills idle + MCPs if fetched) */
@@ -74,7 +72,7 @@ export function computeContextSummary(
   return {
     totalIdleTokens,
     totalActiveTokens,
-    contextLimit: CONTEXT_WINDOW_LIMIT,
+    contextLimit: toolContextWindow(activeTool),
     rulesTokens,
     rulesConditionalTokens,
     skillsIdleTokens,


### PR DESCRIPTION
## Summary

Add `contextWindow` field to tool configuration so context limits scale per AI tool. Gemini uses 1M tokens while others default to 200K. The context window is now dynamically looked up based on the selected tool filter, with proper null-checking against a default fallback.

## Changes

- Added `contextWindow: number` to `ToolConfig` interface
- Set Gemini to 1M, all others to 200K in tool configs
- Exported `toolContextWindow()` helper for querying context limits
- Updated `computeContextSummary()` to use tool-specific limits instead of hardcoded constant

This prepares the context window system for additional tools being added in LOA-12.