### PR TITLE
Expand ecosystem table to show all 10 supported AI coding tools

### DIFF
--- a/src/components/learn/EcosystemTable.tsx
+++ b/src/components/learn/EcosystemTable.tsx
@@ -1,10 +1,9 @@
 import type { SourceTool } from "@/types";
 import { ToolLogo } from "@/components/ToolLogo";
+import { TOOL_CONFIG } from "@/config/tools";
 
 const tools: {
   id: SourceTool;
-  name: string;
-  color: string;
   format: string;
   mcpConfig: string;
   skillsDir: string;
@@ -12,8 +11,6 @@ const tools: {
 }[] = [
   {
     id: "claude",
-    name: "Claude Code",
-    color: "text-orange-500",
     format: "JSON",
     mcpConfig: "~/.claude.json",
     skillsDir: "~/.claude/skills/",
@@ -21,21 +18,66 @@ const tools: {
   },
   {
     id: "codex",
-    name: "Codex CLI",
-    color: "text-green-500",
     format: "TOML",
     mcpConfig: "~/.codex/config.toml",
-    skillsDir: "~/.codex/skills/",
+    skillsDir: "~/.agents/skills/",
     rulesFile: "AGENTS.md",
   },
   {
     id: "gemini",
-    name: "Gemini CLI",
-    color: "text-blue-500",
     format: "JSON",
     mcpConfig: "~/.gemini/settings.json",
     skillsDir: "~/.gemini/skills/",
     rulesFile: "GEMINI.md",
+  },
+  {
+    id: "cursor",
+    format: "JSON",
+    mcpConfig: "~/.cursor/mcp.json",
+    skillsDir: "~/.cursor/skills/",
+    rulesFile: ".cursor/rules/*.mdc",
+  },
+  {
+    id: "copilot",
+    format: "JSON",
+    mcpConfig: "~/.vscode/mcp.json",
+    skillsDir: "~/.copilot/skills/",
+    rulesFile: "copilot-instructions.md",
+  },
+  {
+    id: "windsurf",
+    format: "JSON",
+    mcpConfig: "~/.codeium/windsurf/mcp_config.json",
+    skillsDir: "~/.codeium/windsurf/skills/",
+    rulesFile: ".windsurf/rules/*.md",
+  },
+  {
+    id: "roo",
+    format: "JSON",
+    mcpConfig: "~/.roo/mcp.json",
+    skillsDir: "~/.roo/skills/",
+    rulesFile: ".roo/rules/*.md",
+  },
+  {
+    id: "cline",
+    format: "JSON",
+    mcpConfig: "~/.cline/mcp.json",
+    skillsDir: "~/.cline/skills/",
+    rulesFile: ".clinerules",
+  },
+  {
+    id: "kilo",
+    format: "JSON",
+    mcpConfig: "~/.kilocode/mcp.json",
+    skillsDir: "~/.kilocode/skills/",
+    rulesFile: ".kilocode/rules/*.md",
+  },
+  {
+    id: "opencode",
+    format: "JSON",
+    mcpConfig: "~/.config/opencode/opencode.json",
+    skillsDir: "~/.config/opencode/skills/",
+    rulesFile: "AGENT.md",
   },
 ];
 
@@ -44,8 +86,8 @@ export function EcosystemTable() {
     <div className="rounded-lg border border-border bg-card p-5">
       <h3 className="mb-1 font-semibold">The Ecosystem</h3>
       <p className="mb-4 text-sm text-muted-foreground">
-        Three AI coding tools share the same concepts but store configuration in
-        different files and formats.
+        Loadout supports 10 AI coding tools. They share the same concepts but
+        store configuration in different files and formats.
       </p>
 
       <div className="overflow-x-auto">
@@ -60,12 +102,14 @@ export function EcosystemTable() {
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
-            {tools.map((tool) => (
-              <tr key={tool.name}>
-                <td className={`py-2.5 pr-4 font-medium ${tool.color}`}>
+            {tools.map((tool) => {
+              const config = TOOL_CONFIG[tool.id];
+              return (
+              <tr key={tool.id}>
+                <td className={`py-2.5 pr-4 font-medium ${config.textClass}`}>
                   <span className="inline-flex items-center gap-1.5">
                     <ToolLogo tool={tool.id} size={13} />
-                    {tool.name}
+                    {config.label}
                   </span>
                 </td>
                 <td className="py-2.5 pr-4 text-muted-foreground">
@@ -81,7 +125,8 @@ export function EcosystemTable() {
                   {tool.rulesFile}
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary

Updated the Learn page's ecosystem section to display all 10 supported AI coding tools instead of just the original 3. Tool labels and colors are now pulled from `TOOL_CONFIG` to eliminate duplication. Configuration paths now reflect where each tool actually stores MCPs, skills, and rules.

## Changes

- Added Cursor, Copilot, Windsurf, Roo, Cline, Kilo, and OpenCode to the ecosystem table
- Updated description: "Three AI coding tools" → "Loadout supports 10 AI coding tools"
- Refactored to import `TOOL_CONFIG` for labels/colors instead of hardcoding them
- Fixed Codex skills path: `~/.codex/skills/` → `~/.agents/skills/`