### PR TITLE
Filter sync dialogs to only show installed tools

### DIFF
--- a/src/components/mcps/MCPCard.tsx
+++ b/src/components/mcps/MCPCard.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import type { MCPItem } from "@/types";
 import { cn } from "@/lib/utils";
 import { syncMCPToTools } from "@/lib/api/sync";
+import { ALL_TOOLS } from "@/config/tools";
 import { SyncDialog } from "@/components/sync";
 import { Button } from "@/components/ui/button";
 import { OpenPathButton } from "@/components/ui/open-path-button";
@@ -10,7 +11,6 @@ import { HealthBadge } from "./HealthBadge";
 import { MCPIcon } from "./MCPIcon";
 import { TestHealthDialog } from "./TestHealthDialog";
 import { ToolBadges } from "./ToolBadge";
-import { ALL_TOOLS } from "@/config/tools";
 
 interface MCPCardProps {
   mcp: MCPItem;
@@ -24,9 +24,7 @@ export function MCPCard({ mcp }: MCPCardProps) {
   const envKeys = Object.keys(mcp.env);
   const hasEnv = envKeys.length > 0;
   const isHttp = mcp.mcpType === "http";
-  const missingTools = ALL_TOOLS.filter(
-    (tool) => !mcp.configuredIn.includes(tool)
-  );
+  const hasSyncTargets = mcp.configuredIn.length < ALL_TOOLS.length;
 
   // Display string for the card preview
   const displayString = isHttp
@@ -160,7 +158,7 @@ export function MCPCard({ mcp }: MCPCardProps) {
               label="Open Config"
             />
 
-            {missingTools.length > 0 && (
+            {hasSyncTargets && (
               <Button
                 variant="outline"
                 size="sm"
@@ -170,8 +168,7 @@ export function MCPCard({ mcp }: MCPCardProps) {
                 }}
               >
                 <Share2 className="mr-2 h-3.5 w-3.5" />
-                Sync to {missingTools.length} Other Tool
-                {missingTools.length !== 1 ? "s" : ""}
+                Sync to Other Tools
               </Button>
             )}
           </div>
@@ -187,7 +184,6 @@ export function MCPCard({ mcp }: MCPCardProps) {
           type="mcp"
           name={mcp.name}
           existingTools={mcp.configuredIn}
-          availableTools={ALL_TOOLS}
           onSync={(targetTools) =>
             syncMCPToTools({
               name: mcp.name,

--- a/src/components/sync/AddMCPDialog.tsx
+++ b/src/components/sync/AddMCPDialog.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { X, Plus, Trash2, Loader2 } from "lucide-react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AddMCPRequest, MCPType, SourceTool, PreviewConfig } from "@/types";
 import { addMCPToTools, previewMCPConfigs } from "@/lib/api/sync";
+import { detectInstalledTools } from "@/lib/api/detection";
 import { Button } from "@/components/ui/button";
 import { ToolSelector } from "./ToolSelector";
 import { ConfigPreview } from "./ConfigPreview";
@@ -14,6 +15,30 @@ interface AddMCPDialogProps {
 
 export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
   const queryClient = useQueryClient();
+
+  // Detect installed tools — only show these in the selector
+  const {
+    data: detectionResult,
+    error: detectionError,
+    isPending: isDetectingTools,
+  } = useQuery({
+    queryKey: ["installed-tools"],
+    queryFn: detectInstalledTools,
+  });
+
+  const installedToolIds = useMemo(
+    () =>
+      detectionResult
+        ? (detectionResult.tools.map((t) => t.id) as SourceTool[])
+        : [],
+    [detectionResult]
+  );
+
+  const detectionErrorMessage = detectionError
+    ? detectionError instanceof Error
+      ? detectionError.message
+      : String(detectionError)
+    : null;
 
   // Form state
   const [name, setName] = useState("");
@@ -28,8 +53,9 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
   // Preview state
   const [previews, setPreviews] = useState<PreviewConfig[]>([]);
   const isHttpMCP = mcpType === "http";
-  const disabledTools: SourceTool[] = [];
-  const effectiveTargetTools = targetTools;
+  const effectiveTargetTools = targetTools.filter((tool) =>
+    installedToolIds.includes(tool)
+  );
 
   const buildRequest = (): AddMCPRequest => ({
     name: name.trim(),
@@ -60,10 +86,12 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
   });
 
   const handlePreview = () => {
+    if (detectionErrorMessage) return;
     previewMutation.mutate(buildRequest());
   };
 
   const handleSubmit = () => {
+    if (detectionErrorMessage) return;
     writeMutation.mutate(buildRequest());
   };
 
@@ -97,6 +125,7 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
   };
 
   const isValid =
+    !detectionErrorMessage &&
     name.trim() &&
     effectiveTargetTools.length > 0 &&
     (!isHttpMCP ? command.trim() : url.trim());
@@ -139,6 +168,14 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
               {writeMutation.error instanceof Error
                 ? writeMutation.error.message
                 : String(writeMutation.error)}
+            </div>
+          )}
+          {detectionErrorMessage && (
+            <div className="rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-600">
+              Could not detect installed tools. Sync is blocked until detection
+              succeeds.
+              <br />
+              <span className="text-xs">{detectionErrorMessage}</span>
             </div>
           )}
 
@@ -292,12 +329,16 @@ export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
           )}
 
           {/* Tool Selector */}
+          {isDetectingTools && !detectionErrorMessage && (
+            <p className="text-xs text-muted-foreground">
+              Detecting installed tools...
+            </p>
+          )}
           <ToolSelector
             selectedTools={effectiveTargetTools}
             onToolsChange={setTargetTools}
             type="mcp"
-            disabledTools={disabledTools}
-            disabledReason="Codex CLI only supports stdio MCP servers"
+            availableTools={installedToolIds}
           />
 
           {/* Preview */}

--- a/src/components/sync/ImportSkillDialog.tsx
+++ b/src/components/sync/ImportSkillDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { X, Loader2, Globe, FileUp, AlertCircle, FileText, FolderOpen } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -46,18 +46,30 @@ export function ImportSkillDialog({
   const [editedName, setEditedName] = useState("");
   const [targetTools, setTargetTools] = useState<SourceTool[]>([]);
 
-  // Detect installed tools to pre-select only those
-  const { data: detectionResult } = useQuery({
+  // Detect installed tools — only show these in the selector
+  const {
+    data: detectionResult,
+    error: detectionError,
+    isPending: isDetectingTools,
+  } = useQuery({
     queryKey: ["installed-tools"],
     queryFn: detectInstalledTools,
   });
-
-  // Set default selected tools once detection completes
-  useEffect(() => {
-    if (detectionResult && targetTools.length === 0) {
-      setTargetTools(detectionResult.tools.map((t) => t.id as SourceTool));
-    }
-  }, [detectionResult, targetTools.length]);
+  const installedToolIds = useMemo(
+    () =>
+      detectionResult
+        ? (detectionResult.tools.map((t) => t.id) as SourceTool[])
+        : [],
+    [detectionResult]
+  );
+  const detectionErrorMessage = detectionError
+    ? detectionError instanceof Error
+      ? detectionError.message
+      : String(detectionError)
+    : null;
+  const effectiveTargetTools = targetTools.filter((tool) =>
+    installedToolIds.includes(tool)
+  );
 
   // Fetch skill from URL
   const fetchMutation = useMutation({
@@ -127,11 +139,11 @@ export function ImportSkillDialog({
   };
 
   const handleInstall = () => {
-    if (!preview) return;
+    if (!preview || detectionErrorMessage) return;
     installMutation.mutate({
       name: editedName.trim(),
       content: preview.content,
-      targetTools,
+      targetTools: effectiveTargetTools,
       files: preview.files,
     });
   };
@@ -142,7 +154,11 @@ export function ImportSkillDialog({
     readFileMutation.isPending;
   const fetchError =
     fetchMutation.error || parseMutation.error || readFileMutation.error;
-  const canInstall = preview && editedName.trim() && targetTools.length > 0;
+  const canInstall =
+    preview &&
+    editedName.trim() &&
+    !detectionErrorMessage &&
+    effectiveTargetTools.length > 0;
 
   // Show success state
   if (installMutation.isSuccess && installMutation.data) {
@@ -186,6 +202,17 @@ export function ImportSkillDialog({
                   : installMutation.error instanceof Error
                     ? installMutation.error.message
                     : String(fetchError || installMutation.error)}
+              </span>
+            </div>
+          )}
+          {detectionErrorMessage && (
+            <div className="flex items-start gap-2 rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-600">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                Could not detect installed tools. Skill installation is blocked
+                until detection succeeds.
+                <br />
+                <span className="text-xs">{detectionErrorMessage}</span>
               </span>
             </div>
           )}
@@ -365,15 +392,16 @@ export function ImportSkillDialog({
               </div>
 
               {/* Tool Selector */}
+              {isDetectingTools && !detectionErrorMessage && (
+                <p className="text-xs text-muted-foreground">
+                  Detecting installed tools...
+                </p>
+              )}
               <ToolSelector
-                selectedTools={targetTools}
+                selectedTools={effectiveTargetTools}
                 onToolsChange={setTargetTools}
                 type="skill"
-                availableTools={
-                  detectionResult
-                    ? (detectionResult.tools.map((t) => t.id) as SourceTool[])
-                    : undefined
-                }
+                availableTools={installedToolIds}
               />
 
               {/* Reset button */}

--- a/src/components/sync/InstallSkillDialog.tsx
+++ b/src/components/sync/InstallSkillDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 import { X, Loader2 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { InstallSkillRequest, SourceTool } from "@/types";
@@ -20,18 +20,30 @@ export function InstallSkillDialog({ onClose }: InstallSkillDialogProps) {
   const [instructions, setInstructions] = useState("");
   const [targetTools, setTargetTools] = useState<SourceTool[]>([]);
 
-  // Detect installed tools to pre-select only those
-  const { data: detectionResult } = useQuery({
+  // Detect installed tools — only show these in the selector
+  const {
+    data: detectionResult,
+    error: detectionError,
+    isPending: isDetectingTools,
+  } = useQuery({
     queryKey: ["installed-tools"],
     queryFn: detectInstalledTools,
   });
-
-  // Set default selected tools once detection completes
-  useEffect(() => {
-    if (detectionResult && targetTools.length === 0) {
-      setTargetTools(detectionResult.tools.map((t) => t.id as SourceTool));
-    }
-  }, [detectionResult, targetTools.length]);
+  const installedToolIds = useMemo(
+    () =>
+      detectionResult
+        ? (detectionResult.tools.map((t) => t.id) as SourceTool[])
+        : [],
+    [detectionResult]
+  );
+  const detectionErrorMessage = detectionError
+    ? detectionError instanceof Error
+      ? detectionError.message
+      : String(detectionError)
+    : null;
+  const effectiveTargetTools = targetTools.filter((tool) =>
+    installedToolIds.includes(tool)
+  );
 
   const buildContent = (): string => {
     const lines = [];
@@ -49,7 +61,7 @@ export function InstallSkillDialog({ onClose }: InstallSkillDialogProps) {
   const buildRequest = (): InstallSkillRequest => ({
     name: name.trim(),
     content: buildContent(),
-    targetTools,
+    targetTools: effectiveTargetTools,
     files: [],
   });
 
@@ -61,11 +73,15 @@ export function InstallSkillDialog({ onClose }: InstallSkillDialogProps) {
   });
 
   const handleSubmit = () => {
+    if (detectionErrorMessage) return;
     writeMutation.mutate(buildRequest());
   };
 
   const isValid =
-    name.trim() && instructions.trim() && targetTools.length > 0;
+    !detectionErrorMessage &&
+    name.trim() &&
+    instructions.trim() &&
+    effectiveTargetTools.length > 0;
 
   // Show success state
   if (writeMutation.isSuccess && writeMutation.data) {
@@ -105,6 +121,14 @@ export function InstallSkillDialog({ onClose }: InstallSkillDialogProps) {
               {writeMutation.error instanceof Error
                 ? writeMutation.error.message
                 : String(writeMutation.error)}
+            </div>
+          )}
+          {detectionErrorMessage && (
+            <div className="rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-600">
+              Could not detect installed tools. Skill installation is blocked
+              until detection succeeds.
+              <br />
+              <span className="text-xs">{detectionErrorMessage}</span>
             </div>
           )}
 
@@ -157,15 +181,16 @@ export function InstallSkillDialog({ onClose }: InstallSkillDialogProps) {
           </div>
 
           {/* Tool Selector */}
+          {isDetectingTools && !detectionErrorMessage && (
+            <p className="text-xs text-muted-foreground">
+              Detecting installed tools...
+            </p>
+          )}
           <ToolSelector
-            selectedTools={targetTools}
+            selectedTools={effectiveTargetTools}
             onToolsChange={setTargetTools}
             type="skill"
-            availableTools={
-              detectionResult
-                ? (detectionResult.tools.map((t) => t.id) as SourceTool[])
-                : undefined
-            }
+            availableTools={installedToolIds}
           />
         </div>
 

--- a/src/components/sync/SyncDialog.tsx
+++ b/src/components/sync/SyncDialog.tsx
@@ -1,19 +1,17 @@
 import { useMemo, useState } from "react";
 import { X, Loader2, Share2 } from "lucide-react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { SourceTool } from "@/types";
 import { Button } from "@/components/ui/button";
 import { ToolSelector } from "./ToolSelector";
 import { SuccessConfirmation } from "./SuccessConfirmation";
-import { ALL_TOOLS } from "@/config/tools";
+import { detectInstalledTools } from "@/lib/api/detection";
 
 interface SyncDialogProps {
   type: "mcp" | "skill";
   name: string;
   /** Tools that already have this item */
   existingTools: SourceTool[];
-  /** Restrict sync targets for compatibility (defaults to all tools) */
-  availableTools?: SourceTool[];
   /** Called with selected target tools to perform the sync */
   onSync: (targetTools: SourceTool[]) => Promise<{
     success: boolean;
@@ -29,22 +27,43 @@ export function SyncDialog({
   type,
   name,
   existingTools,
-  availableTools,
   onSync,
   onClose,
   queryKey,
 }: SyncDialogProps) {
   const queryClient = useQueryClient();
-  const allowedTools = useMemo(
-    () => availableTools ?? ALL_TOOLS,
-    [availableTools]
+
+  // Only show tools that are actually installed on the user's machine
+  const {
+    data: detectionResult,
+    error: detectionError,
+    isPending: isDetectingTools,
+  } = useQuery({
+    queryKey: ["installed-tools"],
+    queryFn: detectInstalledTools,
+  });
+
+  const installedToolIds = useMemo(
+    () =>
+      detectionResult
+        ? (detectionResult.tools.map((t) => t.id) as SourceTool[])
+        : [],
+    [detectionResult]
   );
-  const disabledTools = ALL_TOOLS.filter((t) => !allowedTools.includes(t));
-  const missingTools = allowedTools.filter((t) => !existingTools.includes(t));
-  const [targetTools, setTargetTools] = useState<SourceTool[]>(missingTools);
-  const effectiveTargetTools = targetTools.filter((tool) =>
-    allowedTools.includes(tool)
+  const detectionErrorMessage = detectionError
+    ? detectionError instanceof Error
+      ? detectionError.message
+      : String(detectionError)
+    : null;
+
+  // Default to nothing selected — the user picks where to sync
+  const [targetTools, setTargetTools] = useState<SourceTool[]>([]);
+  const effectiveTargetTools = targetTools.filter(
+    (tool) => installedToolIds.includes(tool) && !existingTools.includes(tool)
   );
+  const allSynced =
+    installedToolIds.length > 0 &&
+    installedToolIds.every((t) => existingTools.includes(t));
 
   const syncMutation = useMutation({
     mutationFn: () => onSync(effectiveTargetTools),
@@ -96,28 +115,36 @@ export function SyncDialog({
                 : String(syncMutation.error)}
             </div>
           )}
+          {detectionErrorMessage && (
+            <div className="rounded-md border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-600">
+              Could not detect installed tools. Sync is blocked until detection
+              succeeds.
+              <br />
+              <span className="text-xs">{detectionErrorMessage}</span>
+            </div>
+          )}
 
           <p className="text-sm">
             Sync <span className="font-semibold">{name}</span> to other tools:
           </p>
 
+          {isDetectingTools && !detectionErrorMessage && (
+            <p className="text-xs text-muted-foreground">
+              Detecting installed tools...
+            </p>
+          )}
           <ToolSelector
             selectedTools={effectiveTargetTools}
             onToolsChange={setTargetTools}
             type={type}
             existingTools={existingTools}
-            disabledTools={disabledTools}
-            disabledReason={
-              type === "mcp"
-                ? "stdio only"
-                : undefined
-            }
+            availableTools={installedToolIds}
           />
 
-          {missingTools.length === 0 && (
+          {allSynced && (
             <p className="text-sm text-muted-foreground">
               This {type === "mcp" ? "MCP" : "skill"} is already configured in
-              all tools.
+              all your installed tools.
             </p>
           )}
         </div>
@@ -130,9 +157,10 @@ export function SyncDialog({
           <Button
             onClick={() => syncMutation.mutate()}
             disabled={
+              !!detectionErrorMessage ||
               effectiveTargetTools.length === 0 ||
               syncMutation.isPending ||
-              missingTools.length === 0
+              allSynced
             }
           >
             {syncMutation.isPending && (


### PR DESCRIPTION
Dynamically detect installed AI tools instead of hardcoding all supported tools in sync dialogs. This improves UX by only showing relevant target tools and provides better error messaging when tool detection fails.

**Changes:**
- Add tool detection query in AddMCPDialog, ImportSkillDialog, InstallSkillDialog, and SyncDialog
- Filter available tools based on detectInstalledTools() results  
- Show loading state while detecting tools
- Display error message if detection fails, blocking sync until resolved
- Simplify MCPCard "Sync to Other Tools" label