### PR TITLE
Disable autocorrect on search inputs

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -184,6 +184,9 @@ export function Sidebar() {
                 placeholder="Filter workspaces..."
                 value={filter}
                 onChange={(e) => setFilter(e.target.value)}
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
                 className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
                 autoFocus
               />

--- a/src/components/filters/SearchBar.tsx
+++ b/src/components/filters/SearchBar.tsx
@@ -19,6 +19,9 @@ export function SearchBar({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
         className="h-8 w-full rounded-md border border-border bg-background pl-8 pr-8 text-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring"
       />
       {value && (


### PR DESCRIPTION
Disable browser/OS autocorrect and spell-checking on all search and filter inputs to prevent interference when searching for technical terms, tool names, and configuration values.

- Added `autoCorrect="off"`, `autoCapitalize="off"`, and `spellCheck={false}` to the shared `SearchBar` component (covers Skills, MCPs, Rules, Hooks search bars)
- Added the same attributes to the workspace filter input in the Sidebar

Fixes LOA-24.