### PR TITLE
feat: Increase default window size to 1440x900

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "windows": [
       {
         "title": "Loadout",
-        "width": 1200,
-        "height": 800,
+        "width": 1440,
+        "height": 900,
         "minWidth": 900,
         "minHeight": 600,
         "resizable": true,


### PR DESCRIPTION
Increases the default window size from 1200×800 to 1440×900 when the app launches. This matches the standard resolution of most 13"–15" displays and gives the app more presence on screen without being fullscreen. The minimum window size remains unchanged, ensuring the app stays usable on smaller displays.