### PR TITLE
feat: Add keyboard shortcuts and save feedback to dialogs

### DIFF
--- a/src/components/config/RepoScanResults.tsx
+++ b/src/components/config/RepoScanResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   X,
   GitBranch,
@@ -20,6 +20,7 @@ import { ToolLogo } from "@/components/ToolLogo";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { scanReposWithoutRules } from "@/lib/api/repos";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 /** CLI tools that can generate rules files */
 interface CliTool {
@@ -353,6 +354,8 @@ interface RepoScanModalProps {
  * then shows results. Closes cleanly — nothing persists on the Rules page.
  */
 export function RepoScanModal({ onClose }: RepoScanModalProps) {
+  const stableOnClose = useCallback(() => onClose(), [onClose]);
+  useEscapeKey(stableOnClose);
   const [loading, setLoading] = useState(true);
   const [result, setResult] = useState<RepoScanResult | null>(null);
   const [repos, setRepos] = useState<RepoWithoutRules[]>([]);

--- a/src/components/config/RuleViewer.tsx
+++ b/src/components/config/RuleViewer.tsx
@@ -1,5 +1,5 @@
 import { X, Copy, Check, FolderOpen, Crosshair } from "lucide-react";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { PromptFile } from "@/types";
 import { ToolBadge } from "@/components/mcps/ToolBadge";
@@ -8,6 +8,7 @@ import { saveFileContent } from "@/lib/api/system";
 import { Button } from "@/components/ui/button";
 import { MarkdownPreview } from "@/components/ui/markdown-preview";
 import { OpenPathButton } from "@/components/ui/open-path-button";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 interface RuleViewerProps {
   rule: PromptFile;
@@ -17,6 +18,8 @@ interface RuleViewerProps {
 export function RuleViewer({ rule, onClose }: RuleViewerProps) {
   const queryClient = useQueryClient();
   const [copied, setCopied] = useState(false);
+  const stableOnClose = useCallback(() => onClose(), [onClose]);
+  useEscapeKey(stableOnClose);
 
   const handleSave = async (content: string) => {
     await saveFileContent(rule.path, content);

--- a/src/components/mcps/TestHealthDialog.tsx
+++ b/src/components/mcps/TestHealthDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import {
   X,
   Loader2,
@@ -10,6 +10,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { MCPItem, HealthTestResult } from "@/types";
 import { testMCPHealth } from "@/lib/api/mcps";
 import { Button } from "@/components/ui/button";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 interface TestHealthDialogProps {
   mcp: MCPItem;
@@ -19,6 +20,8 @@ interface TestHealthDialogProps {
 export function TestHealthDialog({ mcp, onClose }: TestHealthDialogProps) {
   const queryClient = useQueryClient();
   const [result, setResult] = useState<HealthTestResult | null>(null);
+  const stableOnClose = useCallback(() => onClose(), [onClose]);
+  useEscapeKey(stableOnClose);
 
   const isHttp = mcp.mcpType === "http";
   const commandDisplay = isHttp

--- a/src/components/skills/SkillViewer.tsx
+++ b/src/components/skills/SkillViewer.tsx
@@ -1,5 +1,5 @@
 import { X, Copy, Check, FolderOpen, Share2, Link2, AlertTriangle } from "lucide-react";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { GroupedSkill, SkillItem } from "@/types";
 import { installSkillToTools } from "@/lib/api/sync";
@@ -14,6 +14,7 @@ import { MarkdownPreview } from "@/components/ui/markdown-preview";
 import { OpenPathButton } from "@/components/ui/open-path-button";
 import { ALL_TOOLS } from "@/config/tools";
 import { cn } from "@/lib/utils";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 interface SkillViewerProps {
   group: GroupedSkill;
@@ -24,6 +25,8 @@ export function SkillViewer({ group, onClose }: SkillViewerProps) {
   const queryClient = useQueryClient();
   const [copied, setCopied] = useState(false);
   const [showSync, setShowSync] = useState(false);
+  const stableOnClose = useCallback(() => onClose(), [onClose]);
+  useEscapeKey(stableOnClose);
   const [activeVariant, setActiveVariant] = useState<SkillItem>(group.primary);
 
   const handleSave = async (body: string) => {
@@ -150,6 +153,7 @@ export function SkillViewer({ group, onClose }: SkillViewerProps) {
             content={activeVariant.content}
             className="h-full"
             onSave={handleSave}
+            onClose={onClose}
           />
         </div>
 

--- a/src/components/sync/AddMCPDialog.tsx
+++ b/src/components/sync/AddMCPDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { X, Plus, Trash2, Loader2 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AddMCPRequest, MCPType, SourceTool, PreviewConfig } from "@/types";
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { ToolSelector } from "./ToolSelector";
 import { ConfigPreview } from "./ConfigPreview";
 import { SuccessConfirmation } from "./SuccessConfirmation";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 interface AddMCPDialogProps {
   onClose: () => void;
@@ -15,6 +16,8 @@ interface AddMCPDialogProps {
 
 export function AddMCPDialog({ onClose }: AddMCPDialogProps) {
   const queryClient = useQueryClient();
+  const stableOnClose = useCallback(() => onClose(), [onClose]);
+  useEscapeKey(stableOnClose);
 
   // Detect installed tools — only show these in the selector
   const {

--- a/src/components/sync/ImportSkillDialog.tsx
+++ b/src/components/sync/ImportSkillDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { X, Loader2, Globe, FileUp, AlertCircle, FileText, FolderOpen } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -15,6 +15,7 @@ import { ToolSelector } from "./ToolSelector";
 import { SuccessConfirmation } from "./SuccessConfirmation";
 import { InstallMethodSelector } from "./InstallMethodSelector";
 import { cn } from "@/lib/utils";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -38,6 +39,8 @@ export function ImportSkillDialog({
   initialFileName,
 }: ImportSkillDialogProps) {
   const queryClient = useQueryClient();
+  const stableOnClose = useCallback(() => onClose(), [onClose]);
+  useEscapeKey(stableOnClose);
 
   const [mode, setMode] = useState<ImportMode>(
     initialFileContent ? "file" : "url"

--- a/src/components/sync/InstallSkillDialog.tsx
+++ b/src/components/sync/InstallSkillDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { X, Loader2 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { InstallMethod, InstallSkillRequest, SourceTool } from "@/types";
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { ToolSelector } from "./ToolSelector";
 import { SuccessConfirmation } from "./SuccessConfirmation";
 import { InstallMethodSelector } from "./InstallMethodSelector";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 interface InstallSkillDialogProps {
   onClose: () => void;
@@ -15,6 +16,8 @@ interface InstallSkillDialogProps {
 
 export function InstallSkillDialog({ onClose }: InstallSkillDialogProps) {
   const queryClient = useQueryClient();
+  const stableOnClose = useCallback(() => onClose(), [onClose]);
+  useEscapeKey(stableOnClose);
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");

--- a/src/components/sync/SyncDialog.tsx
+++ b/src/components/sync/SyncDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { X, Loader2, Share2 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { InstallMethod, SourceTool, WriteResult } from "@/types";
@@ -7,6 +7,7 @@ import { ToolSelector } from "./ToolSelector";
 import { SuccessConfirmation } from "./SuccessConfirmation";
 import { InstallMethodSelector } from "./InstallMethodSelector";
 import { detectInstalledTools } from "@/lib/api/detection";
+import { useEscapeKey } from "@/hooks/useEscapeKey";
 
 interface SyncDialogProps {
   type: "mcp" | "skill";
@@ -32,6 +33,8 @@ export function SyncDialog({
   queryKey,
 }: SyncDialogProps) {
   const queryClient = useQueryClient();
+  const stableOnClose = useCallback(() => onClose(), [onClose]);
+  useEscapeKey(stableOnClose);
 
   // Only show tools that are actually installed on the user's machine
   const {

--- a/src/components/ui/markdown-preview.tsx
+++ b/src/components/ui/markdown-preview.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
@@ -8,13 +8,16 @@ interface MarkdownPreviewProps {
   content: string;
   className?: string;
   onSave?: (content: string) => Promise<void>;
+  onClose?: () => void;
 }
 
-export function MarkdownPreview({ content, className, onSave }: MarkdownPreviewProps) {
+export function MarkdownPreview({ content, className, onSave, onClose }: MarkdownPreviewProps) {
   const [mode, setMode] = useState<"edit" | "preview">("preview");
   const [draft, setDraft] = useState(content);
   const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const isDirty = draft !== content;
 
@@ -23,6 +26,18 @@ export function MarkdownPreview({ content, className, onSave }: MarkdownPreviewP
     setDraft(content);
   }, [content]);
 
+  // Clear saved indicator when user starts editing again
+  useEffect(() => {
+    if (isDirty) setSaved(false);
+  }, [isDirty]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    };
+  }, []);
+
   // Focus textarea when switching to edit mode
   useEffect(() => {
     if (mode === "edit" && textareaRef.current) {
@@ -30,15 +45,51 @@ export function MarkdownPreview({ content, className, onSave }: MarkdownPreviewP
     }
   }, [mode]);
 
-  const handleSave = async () => {
+  const handleSave = useCallback(async () => {
     if (!onSave || !isDirty) return;
     setSaving(true);
     try {
       await onSave(draft);
+      setSaved(true);
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+      savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
     } finally {
       setSaving(false);
     }
-  };
+  }, [onSave, isDirty, draft]);
+
+  const handleSaveAndClose = useCallback(async () => {
+    if (!onSave || !isDirty) {
+      onClose?.();
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSave(draft);
+      onClose?.();
+    } finally {
+      setSaving(false);
+    }
+  }, [onSave, onClose, isDirty, draft]);
+
+  // Keyboard shortcuts: Cmd/Ctrl+S to save, Cmd/Ctrl+Enter to save & close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod || mode !== "edit") return;
+
+      if (e.key === "s") {
+        e.preventDefault();
+        handleSave();
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        handleSaveAndClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [mode, handleSave, handleSaveAndClose]);
 
   const handleDiscard = () => {
     setDraft(content);
@@ -74,22 +125,30 @@ export function MarkdownPreview({ content, className, onSave }: MarkdownPreviewP
           </button>
         </div>
 
-        {/* Save / discard actions (only when dirty in edit mode) */}
-        {mode === "edit" && isDirty && onSave && (
+        {/* Save / discard actions */}
+        {mode === "edit" && onSave && (isDirty || saved) && (
           <div className="flex items-center gap-2">
-            <button
-              onClick={handleDiscard}
-              className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-            >
-              Discard
-            </button>
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-            >
-              {saving ? "Saving..." : "Save"}
-            </button>
+            {saved ? (
+              <span className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white">
+                Saved
+              </span>
+            ) : (
+              <>
+                <button
+                  onClick={handleDiscard}
+                  className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  Discard
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {saving ? "Saving..." : "Save"}
+                </button>
+              </>
+            )}
           </div>
         )}
       </div>

--- a/src/hooks/useEscapeKey.ts
+++ b/src/hooks/useEscapeKey.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+export function useEscapeKey(handler: () => void) {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handler();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handler]);
+}


### PR DESCRIPTION
Improves user experience by adding keyboard shortcuts and visual feedback to dialogs throughout the app.

**Changes:**
- Create `useEscapeKey` hook for consistent Escape key handling across all dialogs
- Add keyboard shortcuts to markdown editor: Cmd/Ctrl+S to save, Cmd/Ctrl+Enter to save & close
- Add visual "Saved" confirmation indicator to editor that displays for 2 seconds after save
- Integrate escape key handling in RepoScan, RuleViewer, TestHealth, SkillViewer, and sync dialogs
- Pass `onClose` callback to MarkdownPreview to support save & close functionality

This creates a more polished and predictable interaction model for all modal dialogs in the application.