### PR TITLE
feat: Update skill and MCP icons to Hammer and Unplug

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import {
   Home,
-  Server,
-  Sparkles,
+  Unplug,
+  Hammer,
   FileText,
   Anchor,
   BarChart3,
@@ -25,8 +25,8 @@ import { TOOL_CONFIG, toolTextColor } from "@/config/tools";
 
 const navItems = [
   { id: "home" as const, label: "Home", icon: Home },
-  { id: "mcps" as const, label: "MCPs", icon: Server },
-  { id: "skills" as const, label: "Skills", icon: Sparkles },
+  { id: "mcps" as const, label: "MCPs", icon: Unplug },
+  { id: "skills" as const, label: "Skills", icon: Hammer },
   { id: "rules" as const, label: "Rules", icon: FileText },
   { id: "hooks" as const, label: "Hooks", icon: Anchor },
   { id: "context" as const, label: "Context", icon: BarChart3 },

--- a/src/components/mcps/MCPList.tsx
+++ b/src/components/mcps/MCPList.tsx
@@ -1,4 +1,4 @@
-import { Filter, Server } from "lucide-react";
+import { Filter, Unplug } from "lucide-react";
 import type { MCPItem } from "@/types";
 import { MCPCard } from "./MCPCard";
 
@@ -32,7 +32,7 @@ export function MCPList({ mcps, hasActiveFilters, onClearFilters }: MCPListProps
 
     return (
       <div className="rounded-lg border border-dashed border-border p-8 text-center">
-        <Server className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+        <Unplug className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
         <h3 className="font-medium">No MCP Servers Found</h3>
         <p className="mt-1 text-sm text-muted-foreground">
           No MCP servers are configured in Claude Code, Codex CLI, or Gemini

--- a/src/components/skills/SkillList.tsx
+++ b/src/components/skills/SkillList.tsx
@@ -1,4 +1,4 @@
-import { Filter, Sparkles } from "lucide-react";
+import { Filter, Hammer } from "lucide-react";
 import { useState } from "react";
 import type { GroupedSkill } from "@/types";
 import { SkillCard } from "./SkillCard";
@@ -36,7 +36,7 @@ export function SkillList({ skills, hasActiveFilters, onClearFilters }: SkillLis
 
     return (
       <div className="rounded-lg border border-dashed border-border p-8 text-center">
-        <Sparkles className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+        <Hammer className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
         <h3 className="font-medium">No Skills Found</h3>
         <p className="mt-1 text-sm text-muted-foreground">
           No skills are configured in Claude Code, Codex CLI, or Gemini CLI.

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import {
-  Server,
-  Sparkles,
+  Unplug,
+  Hammer,
   FileText,
   Anchor,
   RefreshCw,
@@ -424,7 +424,7 @@ export function Home() {
       {/* Stat cards — user-level counts */}
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <StatCard
-          icon={Server}
+          icon={Unplug}
           label="MCP Servers"
           count={mcpsList.length}
           isLoading={mcpsLoading}
@@ -432,7 +432,7 @@ export function Home() {
           onClick={() => setActiveTab("mcps")}
         />
         <StatCard
-          icon={Sparkles}
+          icon={Hammer}
           label="Skills"
           count={skills.length}
           isLoading={skillsLoading}
@@ -511,7 +511,7 @@ export function Home() {
                 )}
               >
                 <div className="flex items-center gap-2">
-                  <Server className="h-3.5 w-3.5 text-muted-foreground" />
+                  <Unplug className="h-3.5 w-3.5 text-muted-foreground" />
                   <span className="text-sm font-medium">{wsWithMCPs}</span>
                 </div>
                 <p className="mt-0.5 text-xs text-muted-foreground">
@@ -549,7 +549,7 @@ export function Home() {
                 )}
               >
                 <div className="flex items-center gap-2">
-                  <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
+                  <Hammer className="h-3.5 w-3.5 text-muted-foreground" />
                   <span className="text-sm font-medium">{wsWithSkills}</span>
                 </div>
                 <p className="mt-0.5 text-xs text-muted-foreground">

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -1,6 +1,6 @@
 import {
-  Server,
-  Sparkles,
+  Unplug,
+  Hammer,
   FileText,
   Anchor,
   BarChart3,
@@ -25,7 +25,7 @@ export function Learn() {
         </h3>
         <div className="grid gap-4 lg:grid-cols-2">
           <ConceptCard
-            icon={Server}
+            icon={Unplug}
             iconColorClass="text-cyan-500"
             iconBgClass="bg-cyan-500/10"
             title="MCPs"
@@ -41,7 +41,7 @@ export function Learn() {
           />
 
           <ConceptCard
-            icon={Sparkles}
+            icon={Hammer}
             iconColorClass="text-purple-500"
             iconBgClass="bg-purple-500/10"
             title="Skills"


### PR DESCRIPTION
## Summary
Replace Sparkles icon with Hammer for Skills and Server icon with Unplug for MCPs. These icons provide better visual distinction and align with Anthropic's design conventions—hammer represents tools/craftsmanship and unplug represents connections/integrations.

## Changes
- Sidebar navigation icons updated
- Home page stat cards and workspace filter icons updated
- Learn page concept card icons updated  
- MCPList and SkillList empty state icons updated

## Files Changed
- src/components/Sidebar.tsx
- src/components/mcps/MCPList.tsx
- src/components/skills/SkillList.tsx
- src/pages/Home.tsx
- src/pages/Learn.tsx