### PR TITLE
Enable auto-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,8 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Loadout ${{ github.ref_name }}"
-          releaseBody: "See [CHANGELOG.md](https://github.com/AmElmo/loadout/blob/main/CHANGELOG.md) for details."
+          releaseBody: "See [CHANGELOG.md](https://github.com/AmElmo/loadout/blob/main/CHANGELOG.md) for the full history."
+          generateReleaseNotes: true
           releaseDraft: true
           prerelease: false
           args: --target ${{ matrix.target }}


### PR DESCRIPTION
Updates the release workflow to enable GitHub's auto-generated release notes. The release page will now show the custom body text at the top, followed by GitHub's auto-generated summary with PR links, commit list, and contributor mentions.