### PR TITLE
fix: resolve unused struct warnings and enhance Learn page timeline UI

### DIFF
--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -212,9 +212,9 @@ pub async fn fetch_agent_from_url(url: String) -> Result<FetchedAgent, String> {
                 owner, repo, ref_and_path
             ),
             GitHubUrl::Tree {
-                owner,
-                repo,
-                ref_and_path,
+                owner: _,
+                repo: _,
+                ref_and_path: _,
             } => {
                 // For a directory URL, we can't know the agent filename — try common patterns
                 // First try fetching as-is (the ref_and_path might point to a .md file)

--- a/src-tauri/src/parsers/plugin_manifest.rs
+++ b/src-tauri/src/parsers/plugin_manifest.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 // === plugin.json (Claude) ===
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct PluginAuthor {
     pub name: String,
     #[serde(default)]
@@ -36,6 +37,7 @@ pub fn parse_plugin_json(path: &Path) -> Result<PluginJson, String> {
 
 /// MCP server entry within a Gemini extension
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct GeminiExtMcpServer {
     #[serde(default)]
     pub command: Option<String>,
@@ -49,6 +51,7 @@ pub struct GeminiExtMcpServer {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 pub struct GeminiExtensionJson {
     pub name: String,
     #[serde(default)]
@@ -71,6 +74,7 @@ pub fn parse_gemini_extension_json(path: &Path) -> Result<GeminiExtensionJson, S
 // === marketplace.json ===
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct MarketplaceOwner {
     pub name: String,
     #[serde(default)]
@@ -78,6 +82,7 @@ pub struct MarketplaceOwner {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct MarketplacePluginEntry {
     pub name: String,
     #[serde(default)]
@@ -93,6 +98,7 @@ pub struct MarketplacePluginEntry {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct MarketplaceJson {
     pub name: String,
     #[serde(default)]
@@ -114,6 +120,7 @@ pub fn parse_marketplace_json(path: &Path) -> Result<MarketplaceJson, String> {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 pub struct InstalledPluginEntry {
     #[serde(default)]
     pub scope: Option<String>,
@@ -130,6 +137,7 @@ pub struct InstalledPluginEntry {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct InstalledPluginsJson {
     #[serde(default)]
     pub version: Option<u32>,

--- a/src-tauri/src/parsers/rules_frontmatter.rs
+++ b/src-tauri/src/parsers/rules_frontmatter.rs
@@ -25,6 +25,7 @@ struct RuleFrontmatter {
 
 /// Parsed scoping info from a rule file
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ParsedRuleScoping {
     /// Glob patterns from frontmatter. None = always loaded.
     pub paths: Option<Vec<String>>,

--- a/src-tauri/src/parsers/skill_md.rs
+++ b/src-tauri/src/parsers/skill_md.rs
@@ -20,12 +20,14 @@ use std::path::Path;
 /// Metadata section in SKILL.md frontmatter
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[allow(dead_code)]
 pub struct SkillMetadata {
     pub short_description: Option<String>,
 }
 
 /// Parsed skill from a SKILL.md file
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ParsedSkill {
     pub name: String,
     pub description: String,

--- a/src/components/learn/ConceptCard.tsx
+++ b/src/components/learn/ConceptCard.tsx
@@ -8,80 +8,130 @@ interface ConceptCardProps {
   icon: LucideIcon;
   iconColorClass: string;
   iconBgClass: string;
+  dotColorClass: string;
+  ringColorClass: string;
+  stepNumber: string;
+  stepNumberColorClass: string;
   title: string;
   description: string;
+  metaphor?: string;
   details: string[];
-  pageTab?: "mcps" | "skills" | "agents" | "rules" | "hooks" | "context";
+  pageTab?: "mcps" | "skills" | "agents" | "rules" | "hooks" | "plugins" | "context";
   pageLabel?: string;
+  isLast?: boolean;
 }
 
 export function ConceptCard({
   icon: Icon,
   iconColorClass,
   iconBgClass,
+  dotColorClass,
+  ringColorClass,
+  stepNumber,
+  stepNumberColorClass,
   title,
   description,
+  metaphor,
   details,
   pageTab,
   pageLabel,
+  isLast,
 }: ConceptCardProps) {
   const [open, setOpen] = useState(false);
   const { setActiveTab } = useWorkspaceStore();
 
   return (
-    <div className="rounded-lg border border-border bg-card">
+    <div className={cn("relative pl-12", !isLast && "pb-4")}>
+      {/* Vertical connector line */}
+      {!isLast && (
+        <div className="absolute left-[11px] top-6 bottom-0 w-[2px] bg-border/60" />
+      )}
+
+      {/* Timeline dot */}
+      <div
+        className={cn(
+          "absolute left-0 top-[14px] h-6 w-6 rounded-full flex items-center justify-center",
+          ringColorClass
+        )}
+      >
+        <div className={cn("h-3 w-3 rounded-full", dotColorClass)} />
+      </div>
+
+      {/* Card */}
       <button
         onClick={() => setOpen(!open)}
-        className="flex w-full items-center gap-3 p-4 text-left transition-colors hover:bg-muted/30"
+        className={cn(
+          "w-full rounded-xl border border-border bg-card p-4 text-left transition-colors hover:bg-muted/30",
+          open && "shadow-sm"
+        )}
       >
-        <div
-          className={cn(
-            "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
-            iconBgClass
-          )}
-        >
-          <Icon className={cn("h-4.5 w-4.5", iconColorClass)} />
-        </div>
-        <div className="min-w-0 flex-1">
-          <h3 className="font-semibold">{title}</h3>
-          <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
-        </div>
-        <ChevronDown
-          className={cn(
-            "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-            open && "rotate-180"
-          )}
-        />
-      </button>
-
-      {open && (
-        <div className="border-t border-border px-4 pb-4 pt-3">
-          <ul className="space-y-1.5">
-            {details.map((detail, i) => (
-              <li
-                key={i}
-                className="flex items-start gap-2 text-xs text-muted-foreground"
+        <div className="flex items-start gap-3">
+          <div
+            className={cn(
+              "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+              iconBgClass
+            )}
+          >
+            <Icon className={cn("h-4.5 w-4.5", iconColorClass)} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span
+                className={cn(
+                  "font-mono text-[10px] font-medium",
+                  stepNumberColorClass
+                )}
               >
-                <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-muted-foreground/40" />
-                <span>{detail}</span>
-              </li>
-            ))}
-          </ul>
-
-          {pageTab && pageLabel && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                setActiveTab(pageTab);
-              }}
-              className="mt-3 flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
-            >
-              {pageLabel}
-              <ArrowRight className="h-3 w-3" />
-            </button>
-          )}
+                {stepNumber}
+              </span>
+              <h3 className="font-semibold leading-tight">{title}</h3>
+            </div>
+            <p className="mt-1 text-sm leading-snug text-muted-foreground">
+              {description}
+            </p>
+            {metaphor && (
+              <p className="mt-1.5 text-xs leading-snug text-muted-foreground/70 italic">
+                {metaphor}
+              </p>
+            )}
+          </div>
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 shrink-0 text-muted-foreground transition-transform mt-1",
+              open && "rotate-180"
+            )}
+          />
         </div>
-      )}
+
+        {open && (
+          <div className="mt-3 border-t border-border pt-3 ml-12">
+            <ul className="space-y-1.5">
+              {details.map((detail, i) => (
+                <li
+                  key={i}
+                  className="flex items-start gap-2 text-xs text-muted-foreground"
+                >
+                  <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-muted-foreground/40" />
+                  <span>{detail}</span>
+                </li>
+              ))}
+            </ul>
+
+            {pageTab && pageLabel && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setActiveTab(pageTab);
+                }}
+                className="mt-3 flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary/80 transition-colors"
+              >
+                {pageLabel}
+                <ArrowRight className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+        )}
+      </button>
     </div>
   );
 }

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -4,8 +4,10 @@ import {
   Bot,
   FileText,
   Anchor,
+  Puzzle,
   BarChart3,
   Layers,
+  Blocks,
 } from "lucide-react";
 import { ConceptCard, EcosystemTable } from "@/components/learn";
 
@@ -15,22 +17,32 @@ export function Learn() {
       <div className="mb-6">
         <h2 className="text-2xl font-semibold">Learn</h2>
         <p className="mt-1 text-muted-foreground">
-          A quick reference to the concepts Loadout helps you manage
+          Master the building blocks that power your AI coding tools — think of
+          it like running a company
         </p>
       </div>
 
       {/* Building Blocks */}
       <div className="mb-8">
-        <h3 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          Building Blocks
-        </h3>
-        <div className="grid gap-4 lg:grid-cols-2">
+        <div className="mb-5 flex items-center gap-2">
+          <Blocks className="h-4 w-4 text-muted-foreground/60" />
+          <h3 className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Building Blocks
+          </h3>
+        </div>
+
+        <div className="max-w-3xl">
           <ConceptCard
             icon={Unplug}
             iconColorClass="text-cyan-500"
             iconBgClass="bg-cyan-500/10"
+            dotColorClass="bg-cyan-400"
+            ringColorClass="bg-cyan-400/15"
+            stepNumber="01"
+            stepNumberColorClass="text-cyan-500/50"
             title="MCPs"
             description="Model Context Protocol servers give AI agents new capabilities — like browsing the web, querying databases, or managing files."
+            metaphor="Think of it as the software your company runs on — Slack, Jira, Salesforce. Each MCP gives the AI access to a new tool it needs to get the job done."
             details={[
               "stdio type: runs a local process via a shell command (e.g., npx, uvx)",
               "http type: connects to a remote URL endpoint",
@@ -45,8 +57,13 @@ export function Learn() {
             icon={Hammer}
             iconColorClass="text-purple-500"
             iconBgClass="bg-purple-500/10"
+            dotColorClass="bg-purple-400"
+            ringColorClass="bg-purple-400/15"
+            stepNumber="02"
+            stepNumberColorClass="text-purple-500/50"
             title="Skills"
             description="Reusable instruction sets stored as SKILL.md files. Invoked as /slash-commands to teach the AI how to do specific tasks."
+            metaphor="Think of it as your company's SOPs and playbooks — documented procedures any employee can pull up when they need to do a specific task the right way."
             details={[
               "Only the description is loaded at idle (low token cost)",
               "Full content loads only when the skill is invoked (active cost)",
@@ -61,8 +78,13 @@ export function Learn() {
             icon={Bot}
             iconColorClass="text-pink-500"
             iconBgClass="bg-pink-500/10"
+            dotColorClass="bg-pink-400"
+            ringColorClass="bg-pink-400/15"
+            stepNumber="03"
+            stepNumberColorClass="text-pink-500/50"
             title="Subagents"
             description="Predefined personas or modes that combine a custom system prompt with optional MCP servers. They let you spin up specialized AI assistants on demand."
+            metaphor="Think of it as contractors you bring in for specialized work — a security auditor, a designer, a tax accountant — each pre-briefed and equipped for their role."
             details={[
               "Defined as markdown files in .claude/agents/ (Claude) or .gemini/agents/ (Gemini)",
               "Each subagent has a name, description, and instruction prompt",
@@ -78,8 +100,13 @@ export function Learn() {
             icon={FileText}
             iconColorClass="text-amber-500"
             iconBgClass="bg-amber-500/10"
+            dotColorClass="bg-amber-400"
+            ringColorClass="bg-amber-400/15"
+            stepNumber="04"
+            stepNumberColorClass="text-amber-500/50"
             title="Rules"
             description="System instruction files injected into the AI's context on every message. They shape how the agent behaves in your project."
+            metaphor="Think of it as your company culture and brand guidelines — the principles everyone internalizes and follows on every decision, without being asked."
             details={[
               "Always-loaded rules: full content in context on every turn",
               "Scoped rules: only loaded when the agent works on matching files",
@@ -94,8 +121,13 @@ export function Learn() {
             icon={Anchor}
             iconColorClass="text-muted-foreground"
             iconBgClass="bg-muted"
+            dotColorClass="bg-zinc-400 dark:bg-zinc-500"
+            ringColorClass="bg-zinc-400/15"
+            stepNumber="05"
+            stepNumberColorClass="text-muted-foreground/50"
             title="Hooks"
             description="Shell commands that run automatically at lifecycle events — before or after a tool call, when a session starts or ends."
+            metaphor="Think of it as your automated workflows — the onboarding checklist that triggers when someone joins, the approval flow that kicks in before a deploy."
             details={[
               "Supported in Claude Code and Gemini CLI",
               "Events: PreToolUse, PostToolUse, SessionStart, SessionEnd, and more",
@@ -107,11 +139,38 @@ export function Learn() {
           />
 
           <ConceptCard
+            icon={Puzzle}
+            iconColorClass="text-orange-500"
+            iconBgClass="bg-orange-500/10"
+            dotColorClass="bg-orange-400"
+            ringColorClass="bg-orange-400/15"
+            stepNumber="06"
+            stepNumberColorClass="text-orange-500/50"
+            title="Plugins"
+            description="Installable packages that bundle MCPs, skills, hooks, agents, and commands into a single unit. Install one plugin and get a whole toolkit pre-wired."
+            metaphor="Think of it as a franchise package — instead of setting up accounting, branding, and training separately, you get the whole turnkey operation in one box."
+            details={[
+              "Supported in Claude Code, Claude Desktop, Gemini CLI (as extensions), and Cursor",
+              "Can contain any combination of: commands, skills, MCP servers, hooks, agents, LSP servers",
+              "Installed via /plugin install or from a marketplace catalog",
+              "Scoped to user-level, project-level, or local — just like other config",
+              "Auto-updated from registered marketplaces on startup",
+            ]}
+            pageTab="plugins"
+            pageLabel="Go to Plugins page"
+          />
+
+          <ConceptCard
             icon={BarChart3}
             iconColorClass="text-primary"
             iconBgClass="bg-primary/10"
+            dotColorClass="bg-primary/70"
+            ringColorClass="bg-primary/10"
+            stepNumber="07"
+            stepNumberColorClass="text-primary/50"
             title="Context Window"
             description="The 200K-token budget shared by all your rules, skills, and MCP tool definitions. Understanding it helps you optimize your setup."
+            metaphor="Think of it as your team's bandwidth — there's only so many things everyone can keep in mind at once. The more policies and tools you pile on, the less headspace left for actual work."
             details={[
               "Idle tokens: consumed on every message, even when items aren't used",
               "Active tokens: consumed only when you invoke a skill",
@@ -126,14 +185,20 @@ export function Learn() {
             icon={Layers}
             iconColorClass="text-emerald-500"
             iconBgClass="bg-emerald-500/10"
+            dotColorClass="bg-emerald-400"
+            ringColorClass="bg-emerald-400/15"
+            stepNumber="08"
+            stepNumberColorClass="text-emerald-500/50"
             title="Scope"
             description="Config items are either user-level (global, applies to all projects) or project-level (specific to a workspace)."
+            metaphor="Think of it as company-wide policy vs. department rules — HR policies apply to everyone, but each team can add their own working agreements on top."
             details={[
               "User-level: stored in your home directory, always active",
               "Project-level: stored in the workspace root, only active there",
               "Shadowing: a project-level item overrides a user-level item with the same name",
               "Select a workspace in the sidebar to see both scopes",
             ]}
+            isLast
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Fix Rust compiler warnings by adding `#[allow(dead_code)]` attributes to unused structs and prefixing unused variables with `_`
- Redesign ConceptCard component with timeline styling (vertical connectors, dots, step numbers)
- Add new Plugins concept card to the Learn page as the 6th building block
- Update all concept descriptions with company metaphors for better mental models

## Changes
- **Backend**: Suppress dead code warnings in parsers and commands
- **Frontend**: New timeline UI for learning concepts with clearer visual flow
- **Content**: Updated intro copy and added metaphorical descriptions to help users understand each concept's role