### PR TITLE
feat: improve download UX with direct links and auto-update workflow

### DIFF
--- a/.github/workflows/update-readme-downloads.yml
+++ b/.github/workflows/update-readme-downloads.yml
@@ -1,0 +1,73 @@
+name: Update README Downloads
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: main
+
+      - name: Update download links and version badge
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG#v}"
+          BASE="https://github.com/AmElmo/loadout/releases/latest/download"
+
+          python3 - "$VERSION" "$BASE" <<'PYEOF'
+          import sys, re
+
+          version = sys.argv[1]
+          base = sys.argv[2]
+
+          table = f"""<!-- DOWNLOAD_TABLE_START -->
+          | Platform | Download |
+          |----------|----------|
+          | macOS (Apple Silicon) | [`.dmg`]({base}/Loadout_{version}_aarch64.dmg) |
+          | macOS (Intel) | [`.dmg`]({base}/Loadout_{version}_x64.dmg) |
+          | Linux | [`.AppImage`]({base}/Loadout_{version}_amd64.AppImage) / [`.deb`]({base}/Loadout_{version}_amd64.deb) |
+          | Windows | [`.exe`]({base}/Loadout_{version}_x64-setup.exe) / [`.msi`]({base}/Loadout_{version}_x64_en-US.msi) |
+          <!-- DOWNLOAD_TABLE_END -->"""
+
+          # Remove leading whitespace from heredoc indentation
+          table = "\n".join(line.lstrip() for line in table.split("\n"))
+
+          with open("README.md", "r") as f:
+              content = f.read()
+
+          # Replace download table
+          content = re.sub(
+              r"<!-- DOWNLOAD_TABLE_START -->.*?<!-- DOWNLOAD_TABLE_END -->",
+              table,
+              content,
+              flags=re.DOTALL,
+          )
+
+          # Update static version badge
+          content = re.sub(
+              r"release-v[\d.]+-",
+              f"release-v{version}-",
+              content,
+          )
+
+          with open("README.md", "w") as f:
+              f.write(content)
+
+          print(f"Updated README for v{version}")
+          PYEOF
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git diff --staged --quiet || git commit -m "chore: update README download links for ${{ github.event.release.tag_name }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ Supports **Claude Code**, **Codex CLI**, **Gemini CLI**, **Cursor**, **Copilot**
 
 Download the latest release for your platform:
 
+<!-- DOWNLOAD_TABLE_START -->
 | Platform | Download |
 |----------|----------|
-| macOS (Apple Silicon) | [`.dmg`](https://github.com/AmElmo/loadout/releases/latest) |
-| macOS (Intel) | [`.dmg`](https://github.com/AmElmo/loadout/releases/latest) |
-| Linux | [`.AppImage`](https://github.com/AmElmo/loadout/releases/latest) / [`.deb`](https://github.com/AmElmo/loadout/releases/latest) |
-| Windows | [`.exe`](https://github.com/AmElmo/loadout/releases/latest) / [`.msi`](https://github.com/AmElmo/loadout/releases/latest) |
+| macOS (Apple Silicon) | [`.dmg`](https://github.com/AmElmo/loadout/releases/latest/download/Loadout_0.2.0_aarch64.dmg) |
+| macOS (Intel) | [`.dmg`](https://github.com/AmElmo/loadout/releases/latest/download/Loadout_0.2.0_x64.dmg) |
+| Linux | [`.AppImage`](https://github.com/AmElmo/loadout/releases/latest/download/Loadout_0.2.0_amd64.AppImage) / [`.deb`](https://github.com/AmElmo/loadout/releases/latest/download/Loadout_0.2.0_amd64.deb) |
+| Windows | [`.exe`](https://github.com/AmElmo/loadout/releases/latest/download/Loadout_0.2.0_x64-setup.exe) / [`.msi`](https://github.com/AmElmo/loadout/releases/latest/download/Loadout_0.2.0_x64_en-US.msi) |
+<!-- DOWNLOAD_TABLE_END -->
 
 Auto-updates are built in — Loadout checks for new versions on launch and every 4 hours.
 


### PR DESCRIPTION
## Summary

Replace confusing releases page links with direct platform-specific downloads. Adds a GitHub Action that automatically updates download links in README whenever a new release is published.

**Problem:** Users landing on `/releases/latest` see 19 assets (.dmg, .AppImage, .deb, .exe, .msi, .sig files) and don't know which to click.

**Solution:** Direct download links (e.g., `/releases/latest/download/Loadout_0.2.0_aarch64.dmg`) that immediately start the download. A new workflow keeps links up-to-date across releases using HTML comment markers as anchors.

## Changes

- **README.md:** Update all 6 download links (macOS, Linux, Windows) to direct asset URLs with version numbers. Add `<!-- DOWNLOAD_TABLE_START/END -->` markers for automation.
- **.github/workflows/update-readme-downloads.yml:** New workflow triggered on release publish. Uses Python regex to update table with new version numbers and asset filenames.