### PR TITLE
chore: harden release workflow retries and updater validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,4 +117,139 @@ jobs:
           releaseBody: ${{ steps.release_notes.outputs.body }}
           releaseDraft: true
           prerelease: false
-          args: --target ${{ matrix.target }}
+          args: --target ${{ matrix.target }} --verbose
+          retryAttempts: 2
+
+  validate-updater:
+    name: Validate updater metadata
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      contents: read
+
+    steps:
+      - name: Validate latest.json on draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import time
+          from urllib.error import HTTPError
+          from urllib.request import Request, urlopen
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+          tag = os.environ["GITHUB_REF_NAME"]
+          token = os.environ["GITHUB_TOKEN"]
+          api_base = f"https://api.github.com/repos/{repo}"
+          expected_platform_prefixes = [
+              "darwin-aarch64",
+              "darwin-x86_64",
+              "linux-x86_64",
+              "windows-x86_64",
+          ]
+
+          def fetch_json(url: str):
+              req = Request(
+                  url,
+                  headers={
+                      "Authorization": f"Bearer {token}",
+                      "Accept": "application/vnd.github+json",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urlopen(req) as resp:
+                  return json.load(resp)
+
+          def fetch_bytes(url: str) -> bytes:
+              req = Request(
+                  url,
+                  headers={
+                      "Authorization": f"Bearer {token}",
+                      "Accept": "application/octet-stream",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urlopen(req) as resp:
+                  return resp.read()
+
+          release = None
+          for attempt in range(10):
+              try:
+                  release = fetch_json(f"{api_base}/releases/tags/{tag}")
+              except HTTPError as exc:
+                  if exc.code != 404 or attempt == 9:
+                      raise
+                  time.sleep(10)
+                  continue
+
+              asset_names = {asset["name"] for asset in release.get("assets", [])}
+              if "latest.json" in asset_names:
+                  break
+              if attempt == 9:
+                  break
+              time.sleep(10)
+
+          if release is None:
+              raise SystemExit(f"Could not find release for tag {tag}")
+
+          assets = release.get("assets", [])
+          asset_names = sorted(asset["name"] for asset in assets)
+          print("Release assets:")
+          for name in asset_names:
+              print(f"  - {name}")
+
+          latest_asset = next((asset for asset in assets if asset["name"] == "latest.json"), None)
+          if latest_asset is None:
+              raise SystemExit("latest.json is missing from the release assets")
+
+          latest_json = json.loads(fetch_bytes(latest_asset["url"]).decode("utf-8"))
+          platforms = latest_json.get("platforms")
+          if not isinstance(platforms, dict):
+              raise SystemExit("latest.json is missing a valid platforms object")
+
+          missing = []
+          invalid = []
+          for prefix in expected_platform_prefixes:
+              matches = [
+                  (key, value)
+                  for key, value in platforms.items()
+                  if key == prefix or key.startswith(prefix + "-")
+              ]
+              if not matches:
+                  missing.append(prefix)
+                  continue
+
+              for key, value in matches:
+                  if not isinstance(value, dict):
+                      invalid.append(f"{key}: entry is not an object")
+                      continue
+                  if not value.get("url"):
+                      invalid.append(f"{key}: missing url")
+                  if not value.get("signature"):
+                      invalid.append(f"{key}: missing signature")
+
+          version = latest_json.get("version")
+          if not isinstance(version, str) or not version.strip():
+              invalid.append("top-level version is missing")
+
+          if missing or invalid:
+              if missing:
+                  print("Missing platforms:")
+                  for item in missing:
+                      print(f"  - {item}")
+              if invalid:
+                  print("Invalid platform entries:")
+                  for item in invalid:
+                      print(f"  - {item}")
+              raise SystemExit("Updater metadata validation failed")
+
+          print("Validated latest.json successfully.")
+          print(f"Version: {version}")
+          print("Platforms:")
+          for key in sorted(platforms):
+              print(f"  - {key}")
+          PY


### PR DESCRIPTION
## Summary
- add verbose Tauri release output
- retry transient release build/upload failures in tauri-action
- validate latest.json before publishing a release

## Why
The macOS Intel release failed during Apple notarization with a transient network error. This hardens the release pipeline and adds visibility for future release failures.