### PR TITLE
fix: improve macOS DMG launch and prune scanner directories

### DIFF
--- a/src-tauri/src/scanners/repos.rs
+++ b/src-tauri/src/scanners/repos.rs
@@ -64,6 +64,8 @@ const PRUNE_DIRS: &[&str] = &[
     ".venv",
     "__pycache__",
     ".tox",
+    "Desktop",
+    "Documents",
     "Pictures",
     "Music",
     "Movies",

--- a/src-tauri/src/scanners/workspaces.rs
+++ b/src-tauri/src/scanners/workspaces.rs
@@ -125,6 +125,8 @@ const PRUNE_DIRS: &[&str] = &[
     ".venv",
     "__pycache__",
     ".tox",
+    "Desktop",
+    "Documents",
     "Pictures",
     "Music",
     "Movies",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,6 +29,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "category": "DeveloperTool",
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary

- Sets the macOS bundle `category` to `DeveloperTool` in `tauri.conf.json`, which fixes DMG launch issues on macOS by providing the required app category metadata.
- Adds `Desktop` and `Documents` to the prune list in both `repos.rs` and `workspaces.rs` scanners to skip these common macOS user directories during file system scans, improving scan performance.

## Test plan

- [ ] Verify the built `.dmg` launches correctly on macOS
- [ ] Confirm repo and workspace scans skip `~/Desktop` and `~/Documents`