### PR TITLE
fix: darken modal backdrop for better focus

### DIFF
--- a/src/components/ui/dialog-overlay.tsx
+++ b/src/components/ui/dialog-overlay.tsx
@@ -19,7 +19,7 @@ export function DialogOverlay({ onClose, children, className }: DialogOverlayPro
   return (
     <div
       className={cn(
-        "fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4",
+        "fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4",
         className,
       )}
       onClick={handleBackdropClick}


### PR DESCRIPTION
## Summary
- Increases modal backdrop opacity from 50% to 70% so background content is less readable when a modal is open
- Adds `backdrop-blur-sm` for a subtle blur effect, following common UX patterns (Apple, Material Design)
- Applies to all modals app-wide via the shared `DialogOverlay` component

## Test plan
- Open any modal (Skills, Rules, MCPs, etc.) and verify the background is noticeably darker
- Confirm the subtle blur effect on background content
- Ensure modals still close when clicking outside the content area