### PR TITLE
fix: allow draft release validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,8 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build
     permissions:
-      contents: read
+      # Draft releases are only visible to tokens with push access.
+      contents: write
 
     steps:
       - name: Validate latest.json on draft release


### PR DESCRIPTION
## Summary
The updater validation job was using `contents: read`, which cannot list draft releases through the GitHub releases API.
This changes the `validate-updater` job to `contents: write` so the draft release for the current tag is visible during validation.
I also left a short inline comment in the workflow explaining why this permission is required.
Local verification: the `latest.json` metadata for `v0.3.0` validates successfully once the release is visible.