### PR TITLE
feat: add full-screen onboarding flow for first-time users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Sidebar } from "@/components/Sidebar";
 import { Header } from "@/components/Header";
 import { UpdateNotification } from "@/components/UpdateNotification";
 import { KeyboardShortcutsModal } from "@/components/KeyboardShortcutsModal";
+import { OnboardingOverlay } from "@/components/onboarding/OnboardingOverlay";
 import { Home } from "@/pages/Home";
 import { MCPs } from "@/pages/MCPs";
 import { Skills } from "@/pages/Skills";
@@ -14,12 +15,14 @@ import { Learn } from "@/pages/Learn";
 import { Repos } from "@/pages/Repos";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useShortcutStore } from "@/stores/shortcutStore";
+import { useOnboardingStore } from "@/stores/onboardingStore";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useEffect, useRef } from "react";
 
 function App() {
   const { activeTab, setSelectedRepo } = useWorkspaceStore();
   const showShortcutsModal = useShortcutStore((s) => s.showShortcutsModal);
+  const showOnboarding = useOnboardingStore((s) => s.showOnboarding);
   const mainRef = useRef<HTMLElement>(null);
   useKeyboardShortcuts();
 
@@ -68,6 +71,7 @@ function App() {
       </div>
       <UpdateNotification />
       {showShortcutsModal && <KeyboardShortcutsModal />}
+      {showOnboarding && <OnboardingOverlay />}
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,11 +14,13 @@ import {
   Sun,
   Moon,
   Monitor,
+  RotateCcw,
 } from "lucide-react";
 import { getVersion } from "@tauri-apps/api/app";
 import { cn } from "@/lib/utils";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
 import { useShortcutStore } from "@/stores/shortcutStore";
+import { useOnboardingStore } from "@/stores/onboardingStore";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useThemeStore } from "@/stores/themeStore";
 
@@ -48,6 +50,7 @@ function SettingsMenu({ version }: { version: string }) {
   const setShowShortcutsModal = useShortcutStore(
     (s) => s.setShowShortcutsModal
   );
+  const replayOnboarding = useOnboardingStore((s) => s.replayOnboarding);
   const { theme, setTheme } = useThemeStore();
 
   useEffect(() => {
@@ -93,6 +96,16 @@ function SettingsMenu({ version }: { version: string }) {
             <span className="text-[10px] text-muted-foreground">
               {isMac ? "\u2318" : "Ctrl"}+/
             </span>
+          </button>
+          <button
+            onClick={() => {
+              replayOnboarding();
+              setOpen(false);
+            }}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-foreground hover:bg-accent"
+          >
+            <RotateCcw className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="flex-1">See Onboarding Again</span>
           </button>
           <div className="mx-2 my-1 border-t border-border" />
           <div className="flex items-center gap-2 px-3 py-1.5">

--- a/src/components/onboarding/LoadoutLogo.tsx
+++ b/src/components/onboarding/LoadoutLogo.tsx
@@ -1,0 +1,11 @@
+export function LoadoutLogo({ className, stroke = "#3B82F6", fill = "#3B82F6" }: { className?: string; stroke?: string; fill?: string }) {
+  return (
+    <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" className={className}>
+      <circle cx="32" cy="32" r="24" fill="none" stroke={stroke} strokeWidth="5" />
+      <line x1="32" y1="8" x2="32" y2="56" stroke={stroke} strokeWidth="3" />
+      <line x1="11" y1="20" x2="53" y2="44" stroke={stroke} strokeWidth="3" />
+      <line x1="53" y1="20" x2="11" y2="44" stroke={stroke} strokeWidth="3" />
+      <path d="M32,8 A24,24 0 0,1 52.8,20 L32,32 Z" fill={fill} />
+    </svg>
+  );
+}

--- a/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/components/onboarding/OnboardingOverlay.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useCallback } from "react";
+import { useOnboardingStore, TOTAL_SLIDES } from "@/stores/onboardingStore";
+import { LogoRevealSlide } from "./slides/LogoRevealSlide";
+import { ToolsOrbitSlide } from "./slides/ToolsOrbitSlide";
+import { MCPsSlide } from "./slides/MCPsSlide";
+import { SkillsSlide } from "./slides/SkillsSlide";
+import { HooksAgentsSlide } from "./slides/HooksAgentsSlide";
+import { CTASlide } from "./slides/CTASlide";
+
+const SLIDES = [LogoRevealSlide, ToolsOrbitSlide, MCPsSlide, SkillsSlide, HooksAgentsSlide, CTASlide];
+
+export function OnboardingOverlay() {
+  const { currentSlide, goToSlide, nextSlide, prevSlide, completeOnboarding } = useOnboardingStore();
+
+  const isLastSlide = currentSlide === TOTAL_SLIDES - 1;
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight" || e.key === " ") {
+        e.preventDefault();
+        nextSlide();
+      }
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        prevSlide();
+      }
+      if (e.key === "Escape") {
+        completeOnboarding();
+      }
+    },
+    [nextSlide, prevSlide, completeOnboarding]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Auto-advance from logo slide after 2.5s
+  useEffect(() => {
+    if (currentSlide !== 0) return;
+    const timer = setTimeout(() => nextSlide(), 2500);
+    return () => clearTimeout(timer);
+  }, [currentSlide, nextSlide]);
+
+  return (
+    <div className="ob-overlay">
+      {/* Progress bar */}
+      <div
+        className="ob-progress-bar"
+        style={{ width: `${(currentSlide / (TOTAL_SLIDES - 1)) * 100}%` }}
+      />
+
+      {/* Background effects */}
+      <div className="ob-bg-grid" />
+      <div className="ob-bg-glow" />
+
+      {/* Slides */}
+      <div className="ob-slides">
+        {SLIDES.map((SlideComponent, i) => (
+          <div
+            key={i}
+            className={`ob-slide ${currentSlide === i ? "ob-slide-active" : ""}`}
+          >
+            <SlideComponent />
+          </div>
+        ))}
+      </div>
+
+      {/* Bottom navigation */}
+      {!isLastSlide && (
+        <div className="ob-nav-bar">
+          <button className="ob-nav-btn ob-nav-secondary" onClick={completeOnboarding}>
+            Skip
+          </button>
+          <div className="ob-nav-dots">
+            {Array.from({ length: TOTAL_SLIDES }, (_, i) => (
+              <button
+                key={i}
+                className={`ob-nav-dot ${currentSlide === i ? "ob-nav-dot-active" : ""}`}
+                onClick={() => goToSlide(i)}
+              />
+            ))}
+          </div>
+          <button className="ob-nav-btn ob-nav-primary" onClick={nextSlide}>
+            Next
+          </button>
+        </div>
+      )}
+
+      <div className="ob-kbd-hint">
+        Press <kbd>→</kbd> or <kbd>Space</kbd> to continue
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/slides/CTASlide.tsx
+++ b/src/components/onboarding/slides/CTASlide.tsx
@@ -1,0 +1,18 @@
+import { LoadoutLogo } from "../LoadoutLogo";
+import { useOnboardingStore } from "@/stores/onboardingStore";
+
+export function CTASlide() {
+  const completeOnboarding = useOnboardingStore((s) => s.completeOnboarding);
+
+  return (
+    <div className="ob-slide-content">
+      <LoadoutLogo className="ob-cta-logo" />
+      <div className="ob-slide-title" style={{ fontSize: "2.8rem" }}>
+        Gear up your AI tools.
+      </div>
+      <button className="ob-cta-btn" onClick={completeOnboarding}>
+        Open Dashboard
+      </button>
+    </div>
+  );
+}

--- a/src/components/onboarding/slides/HooksAgentsSlide.tsx
+++ b/src/components/onboarding/slides/HooksAgentsSlide.tsx
@@ -1,0 +1,38 @@
+const CARDS = [
+  { label: "Hooks", color: "#f97316" },
+  { label: "Subagents", color: "#3b82f6" },
+  { label: "Plugins", color: "#22c55e" },
+  { label: "Context Window", color: "#a855f7" },
+  { label: "Repos", color: "#f43f5e" },
+  { label: "Rules", color: "#14b8a6" },
+  { label: "Learn", color: "#f59e0b" },
+];
+
+export function HooksAgentsSlide() {
+  return (
+    <div className="ob-slide-content">
+      <div className="ob-slide-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="3" width="7" height="7" rx="1" /><rect x="14" y="3" width="7" height="7" rx="1" /><rect x="3" y="14" width="7" height="7" rx="1" /><rect x="14" y="14" width="7" height="7" rx="1" />
+        </svg>
+      </div>
+      <div className="ob-slide-title">Hooks, Agents & more</div>
+      <div className="ob-slide-subtitle">
+        Event-driven hooks, subagent configurations, plugins — manage every layer of your AI stack.
+      </div>
+
+      <div className="ob-feature-cards">
+        {CARDS.map((card, i) => (
+          <div
+            key={card.label}
+            className="ob-feature-card"
+            style={{ animationDelay: `${0.3 + i * 0.1}s` }}
+          >
+            <div className="ob-card-dot" style={{ background: card.color }} />
+            {card.label}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/slides/LogoRevealSlide.tsx
+++ b/src/components/onboarding/slides/LogoRevealSlide.tsx
@@ -1,0 +1,11 @@
+import { LoadoutLogo } from "../LoadoutLogo";
+
+export function LogoRevealSlide() {
+  return (
+    <div className="ob-logo-container">
+      <LoadoutLogo className="ob-logo-svg" />
+      <div className="ob-logo-text">Loadout</div>
+      <div className="ob-logo-tagline">Gear up your AI tools</div>
+    </div>
+  );
+}

--- a/src/components/onboarding/slides/MCPsSlide.tsx
+++ b/src/components/onboarding/slides/MCPsSlide.tsx
@@ -1,0 +1,38 @@
+export function MCPsSlide() {
+  return (
+    <div className="ob-slide-content">
+      <div className="ob-slide-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="2" y="6" width="20" height="12" rx="2" /><path d="M6 12h4" /><path d="M14 12h4" />
+        </svg>
+      </div>
+      <div className="ob-slide-title">MCP Servers</div>
+      <div className="ob-slide-subtitle">
+        See all your Model Context Protocol servers at a glance — their health, tools, and which AI agents connect to them.
+      </div>
+
+      <div className="ob-mcp-visual">
+        <div className="ob-mcp-server">
+          <div className="ob-mcp-icon">🗄️</div>
+          <div style={{ fontWeight: 600, fontSize: "0.85rem" }}>PostgreSQL</div>
+          <div className="ob-mcp-label">stdio</div>
+          <div className="ob-mcp-status" />
+        </div>
+        <div className="ob-mcp-connector" />
+        <div className="ob-mcp-server">
+          <div className="ob-mcp-icon">🔍</div>
+          <div style={{ fontWeight: 600, fontSize: "0.85rem" }}>Grep</div>
+          <div className="ob-mcp-label">stdio</div>
+          <div className="ob-mcp-status" />
+        </div>
+        <div className="ob-mcp-connector" />
+        <div className="ob-mcp-server">
+          <div className="ob-mcp-icon">🌐</div>
+          <div style={{ fontWeight: 600, fontSize: "0.85rem" }}>Browser</div>
+          <div className="ob-mcp-label">http</div>
+          <div className="ob-mcp-status" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/slides/SkillsSlide.tsx
+++ b/src/components/onboarding/slides/SkillsSlide.tsx
@@ -1,0 +1,33 @@
+export function SkillsSlide() {
+  const skills = [
+    { icon: "⚡", name: "commit", tokens: "~1,240 tokens", tool: "Claude", bg: "rgba(249,115,22,0.1)", color: "#f97316" },
+    { icon: "🔍", name: "review-pr", tokens: "~2,100 tokens", tool: "Claude", bg: "rgba(249,115,22,0.1)", color: "#f97316" },
+    { icon: "📋", name: "spec-issue", tokens: "~890 tokens", tool: "Cursor", bg: "rgba(168,85,247,0.1)", color: "#a855f7" },
+    { icon: "🧪", name: "test-runner", tokens: "~650 tokens", tool: "Codex", bg: "rgba(34,197,94,0.1)", color: "#22c55e" },
+  ];
+
+  return (
+    <div className="ob-slide-content">
+      <div className="ob-slide-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        </svg>
+      </div>
+      <div className="ob-slide-title">Skills & Rules</div>
+      <div className="ob-slide-subtitle">
+        Audit skills, system prompts, and rules that shape your AI's behavior. Track token costs before they hit your context window.
+      </div>
+
+      <div className="ob-skills-cascade">
+        {skills.map((s, i) => (
+          <div key={s.name} className="ob-skill-row" style={{ animationDelay: `${0.2 + i * 0.15}s` }}>
+            <span style={{ fontSize: "1.1rem" }}>{s.icon}</span>
+            <span className="ob-skill-name">{s.name}</span>
+            <span className="ob-skill-tokens">{s.tokens}</span>
+            <span className="ob-skill-badge" style={{ background: s.bg, color: s.color }}>{s.tool}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/slides/ToolsOrbitSlide.tsx
+++ b/src/components/onboarding/slides/ToolsOrbitSlide.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+import { ToolLogo } from "@/components/ToolLogo";
+import { LoadoutLogo } from "../LoadoutLogo";
+import type { SourceTool } from "@/types";
+
+const TOOLS: { tool: SourceTool; color: string }[] = [
+  { tool: "claude", color: "#f97316" },
+  { tool: "codex", color: "#22c55e" },
+  { tool: "gemini", color: "#3b82f6" },
+  { tool: "cursor", color: "#a855f7" },
+  { tool: "copilot", color: "#0ea5e9" },
+  { tool: "windsurf", color: "#14b8a6" },
+  { tool: "roo", color: "#f43f5e" },
+  { tool: "cline", color: "#f59e0b" },
+  { tool: "kilo", color: "#84cc16" },
+  { tool: "opencode", color: "#6366f1" },
+];
+
+const RADIUS = 120;
+const CENTER = 150;
+const TOOL_SIZE = 40;
+
+export function ToolsOrbitSlide() {
+  const toolPositions = useMemo(() =>
+    TOOLS.map((_, i) => {
+      const angle = (i / TOOLS.length) * Math.PI * 2 - Math.PI / 2;
+      return {
+        x: CENTER + Math.cos(angle) * RADIUS - TOOL_SIZE / 2,
+        y: CENTER + Math.sin(angle) * RADIUS - TOOL_SIZE / 2,
+      };
+    }), []);
+
+  return (
+    <div className="ob-slide-content">
+      <div className="ob-slide-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 2L2 7l10 5 10-5-10-5z" /><path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" />
+        </svg>
+      </div>
+      <div className="ob-slide-title">10 AI tools. One dashboard.</div>
+      <div className="ob-slide-subtitle">Manage configurations across every major AI coding assistant from a single place.</div>
+
+      <div className="ob-orbit-container">
+        <div className="ob-orbit-ring" />
+        <div className="ob-orbit-center">
+          <LoadoutLogo className="w-7 h-7" stroke="white" fill="white" />
+        </div>
+        {TOOLS.map(({ tool, color }, i) => (
+          <div
+            key={tool}
+            className="ob-orbit-tool"
+            style={{
+              left: toolPositions[i].x,
+              top: toolPositions[i].y,
+              animationDelay: `${0.3 + i * 0.08}s`,
+              color,
+            }}
+          >
+            <ToolLogo tool={tool} size={18} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -219,3 +219,456 @@ body {
 .markdown-body del {
   color: var(--color-muted-foreground);
 }
+
+/* ─── Onboarding ─── */
+
+.ob-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: #0a0a0f;
+  color: #fafafa;
+  overflow: hidden;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}
+
+.ob-progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 2px;
+  background: #3b82f6;
+  z-index: 210;
+  transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ob-bg-grid {
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(59, 130, 246, 0.03) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(59, 130, 246, 0.03) 1px, transparent 1px);
+  background-size: 60px 60px;
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 50%, black 30%, transparent 100%);
+  z-index: 0;
+}
+
+.ob-bg-glow {
+  position: fixed;
+  width: 600px;
+  height: 600px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.08) 0%, transparent 70%);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 0;
+  animation: ob-breathe 6s ease-in-out infinite;
+}
+
+@keyframes ob-breathe {
+  0%, 100% { transform: translate(-50%, -50%) scale(1); opacity: 0.6; }
+  50% { transform: translate(-50%, -50%) scale(1.2); opacity: 1; }
+}
+
+/* Slides */
+.ob-slides {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.ob-slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ob-slide-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ob-slide-active .ob-slide-content {
+  animation: ob-slideUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes ob-slideUp {
+  from { opacity: 0; transform: translateY(40px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Slide content */
+.ob-slide-content {
+  text-align: center;
+  z-index: 1;
+  max-width: 800px;
+  padding: 0 40px;
+  opacity: 0;
+}
+
+.ob-slide-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 24px;
+  color: #3b82f6;
+}
+
+.ob-slide-title {
+  font-size: 2.2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+  line-height: 1.2;
+  color: #fafafa;
+}
+
+.ob-slide-subtitle {
+  color: #71717a;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+/* Logo reveal (slide 0) */
+.ob-logo-container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.ob-logo-svg {
+  width: 80px;
+  height: 80px;
+  animation: ob-logoAppear 1.2s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.ob-logo-text {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin-top: 20px;
+  animation: ob-logoAppear 1.2s 0.2s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.ob-logo-tagline {
+  color: #71717a;
+  font-size: 1.1rem;
+  font-weight: 400;
+  margin-top: 8px;
+  animation: ob-logoAppear 1.2s 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes ob-logoAppear {
+  from { opacity: 0; transform: scale(0.5) rotate(-10deg); }
+  to { opacity: 1; transform: scale(1) rotate(0); }
+}
+
+/* Orbit (slide 1) */
+.ob-orbit-container {
+  position: relative;
+  width: 300px;
+  height: 300px;
+  margin: 36px auto 0;
+}
+
+.ob-orbit-ring {
+  position: absolute;
+  inset: 20px;
+  border: 1px solid rgba(30, 30, 35, 0.6);
+  border-radius: 50%;
+}
+
+.ob-orbit-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 52px;
+  height: 52px;
+  background: #3b82f6;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  box-shadow: 0 0 40px rgba(59, 130, 246, 0.3);
+}
+
+.ob-orbit-tool {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  border-radius: 11px;
+  background: #141417;
+  border: 1px solid #1e1e23;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  z-index: 3;
+  transition: border-color 0.3s;
+}
+
+.ob-orbit-tool:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.ob-slide-active .ob-orbit-tool {
+  animation: ob-toolAppear 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes ob-toolAppear {
+  to { opacity: 1; }
+}
+
+/* MCP visual (slide 2) */
+.ob-mcp-visual {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: 40px;
+}
+
+.ob-mcp-server {
+  background: #141417;
+  border: 1px solid #1e1e23;
+  border-radius: 12px;
+  padding: 20px 24px;
+  text-align: center;
+  opacity: 0;
+  transform: scale(0.9);
+}
+
+.ob-slide-active .ob-mcp-server {
+  animation: ob-mcpIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.ob-slide-active .ob-mcp-server:nth-child(1) { animation-delay: 0.3s; }
+.ob-slide-active .ob-mcp-server:nth-child(3) { animation-delay: 0.4s; }
+.ob-slide-active .ob-mcp-server:nth-child(5) { animation-delay: 0.5s; }
+
+@keyframes ob-mcpIn {
+  to { opacity: 1; transform: scale(1); }
+}
+
+.ob-mcp-connector {
+  width: 40px;
+  height: 2px;
+  background: linear-gradient(90deg, #3b82f6, transparent);
+  opacity: 0;
+}
+
+.ob-slide-active .ob-mcp-connector {
+  animation: ob-connectorIn 0.6s 0.6s ease forwards;
+}
+
+@keyframes ob-connectorIn {
+  to { opacity: 1; }
+}
+
+.ob-mcp-icon { font-size: 1.5rem; margin-bottom: 8px; }
+.ob-mcp-label { font-size: 0.8rem; color: #71717a; }
+.ob-mcp-status { width: 6px; height: 6px; background: #22c55e; border-radius: 50%; margin: 8px auto 0; }
+
+/* Skills cascade (slide 3) */
+.ob-skills-cascade {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 40px;
+  width: 100%;
+  max-width: 480px;
+}
+
+.ob-skill-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #141417;
+  border: 1px solid #1e1e23;
+  border-radius: 10px;
+  padding: 12px 16px;
+  opacity: 0;
+  transform: translateX(-30px);
+}
+
+.ob-slide-active .ob-skill-row {
+  animation: ob-skillSlide 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes ob-skillSlide {
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.ob-skill-name { font-size: 0.9rem; font-weight: 500; flex: 1; text-align: left; }
+.ob-skill-tokens { font-size: 0.75rem; color: #71717a; font-variant-numeric: tabular-nums; }
+.ob-skill-badge { font-size: 0.65rem; padding: 2px 8px; border-radius: 20px; font-weight: 600; }
+
+/* Feature cards (slide 4) */
+.ob-feature-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 40px;
+  justify-content: center;
+}
+
+.ob-feature-card {
+  background: #141417;
+  border: 1px solid #1e1e23;
+  border-radius: 12px;
+  padding: 14px 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  opacity: 0;
+  transform: translateY(20px);
+  white-space: nowrap;
+}
+
+.ob-slide-active .ob-feature-card {
+  animation: ob-cardFloat 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+@keyframes ob-cardFloat {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.ob-card-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* CTA (slide 5) */
+.ob-cta-logo {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 24px;
+  display: block;
+  animation: ob-logoAppear 1s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.ob-cta-btn {
+  background: #3b82f6;
+  color: white;
+  border: none;
+  padding: 14px 40px;
+  border-radius: 12px;
+  font-size: 1.05rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  margin-top: 32px;
+  transition: all 0.2s ease;
+  box-shadow: 0 0 30px rgba(59, 130, 246, 0.2);
+}
+
+.ob-cta-btn:hover {
+  background: #2563eb;
+  transform: translateY(-2px);
+  box-shadow: 0 0 40px rgba(59, 130, 246, 0.3);
+}
+
+/* Navigation */
+.ob-nav-bar {
+  position: fixed;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  z-index: 210;
+}
+
+.ob-nav-dots {
+  display: flex;
+  gap: 8px;
+}
+
+.ob-nav-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #1e1e23;
+  border: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  padding: 0;
+}
+
+.ob-nav-dot-active {
+  background: #3b82f6;
+  width: 24px;
+  border-radius: 4px;
+}
+
+.ob-nav-btn {
+  border: none;
+  padding: 10px 24px;
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.2s ease;
+}
+
+.ob-nav-primary {
+  background: #3b82f6;
+  color: white;
+}
+
+.ob-nav-primary:hover {
+  background: #2563eb;
+  transform: translateY(-1px);
+}
+
+.ob-nav-secondary {
+  background: transparent;
+  color: #71717a;
+}
+
+.ob-nav-secondary:hover {
+  color: #fafafa;
+}
+
+.ob-kbd-hint {
+  position: fixed;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #71717a;
+  font-size: 0.7rem;
+  opacity: 0.5;
+  z-index: 210;
+}
+
+.ob-kbd-hint kbd {
+  background: #141417;
+  border: 1px solid #1e1e23;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.65rem;
+}

--- a/src/stores/onboardingStore.ts
+++ b/src/stores/onboardingStore.ts
@@ -1,0 +1,63 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export const TOTAL_SLIDES = 6;
+
+interface OnboardingState {
+  hasCompletedOnboarding: boolean;
+  showOnboarding: boolean;
+  currentSlide: number;
+
+  setShowOnboarding: (show: boolean) => void;
+  goToSlide: (n: number) => void;
+  nextSlide: () => void;
+  prevSlide: () => void;
+  completeOnboarding: () => void;
+  replayOnboarding: () => void;
+}
+
+export const useOnboardingStore = create<OnboardingState>()(
+  persist(
+    (set, get) => ({
+      hasCompletedOnboarding: false,
+      showOnboarding: false,
+      currentSlide: 0,
+
+      setShowOnboarding: (show) => set({ showOnboarding: show }),
+
+      goToSlide: (n) => {
+        if (n >= 0 && n < TOTAL_SLIDES) set({ currentSlide: n });
+      },
+
+      nextSlide: () => {
+        const { currentSlide } = get();
+        if (currentSlide < TOTAL_SLIDES - 1) set({ currentSlide: currentSlide + 1 });
+      },
+
+      prevSlide: () => {
+        const { currentSlide } = get();
+        if (currentSlide > 0) set({ currentSlide: currentSlide - 1 });
+      },
+
+      completeOnboarding: () => {
+        set({ hasCompletedOnboarding: true, showOnboarding: false, currentSlide: 0 });
+      },
+
+      replayOnboarding: () => {
+        set({ showOnboarding: true, currentSlide: 0 });
+      },
+    }),
+    {
+      name: "loadout-onboarding",
+      partialize: (state) => ({
+        hasCompletedOnboarding: state.hasCompletedOnboarding,
+      }),
+      onRehydrateStorage: () => (state) => {
+        // On first launch (hasn't completed), show the onboarding
+        if (state && !state.hasCompletedOnboarding) {
+          state.showOnboarding = true;
+        }
+      },
+    }
+  )
+);


### PR DESCRIPTION
## Summary

- Adds a cinematic 6-slide onboarding overlay (logo reveal, 10-tool orbit with real logos, MCP servers, skills & rules, hooks/agents, and CTA) that triggers automatically on first app launch
- Onboarding completion is persisted via localStorage so it only shows once
- Adds "See Onboarding Again" option in the Settings menu to replay the flow
- All onboarding CSS is namespaced with `ob-` prefix and forces dark theme for a consistent branded experience

## Test plan

- [ ] Fresh launch (clear localStorage) shows onboarding automatically
- [ ] Clicking "Open Dashboard" or "Skip" completes onboarding and shows the main app
- [ ] Subsequent launches go straight to the dashboard
- [ ] Settings → "See Onboarding Again" replays the full onboarding
- [ ] Arrow keys, Space, and Escape navigate/dismiss the onboarding