### PR TITLE
Tighten launch readiness and stabilize tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,14 @@
 
 ### Added
 
-- Revamp workspace navigation with Repos page and simplified sidebar (#120)
+- Revamp workspace navigation with a dedicated Repos page and simplified sidebar (#120)
 - Add delete flows for MCPs, skills, and agents (LOA-38) (#118)
 
 ### Fixed
 
-- Correct asset paths and add landing page resources (#119)
+- Correct landing page asset paths (#119)
 - Add macOS bundle category and prune Desktop/Documents from scans (#113)
-- Use list releases API to find drafts in updater validation
+- Fix draft release detection in updater validation
 - Darken modal backdrop for better focus (#114)
 
 ## [0.2.3] - 2026-04-01

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <p align="center">
   <a href="https://github.com/AmElmo/loadout/releases/latest"><img src="https://img.shields.io/github/v/release/AmElmo/loadout?style=flat-square&color=3B82F6" alt="Latest Release"></a>
   <a href="https://github.com/AmElmo/loadout/releases"><img src="https://img.shields.io/github/downloads/AmElmo/loadout/total?style=flat-square&color=10b981" alt="Downloads"></a>
-  <a href="https://github.com/AmElmo/loadout/blob/main/src-tauri/Cargo.toml#L6"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License"></a>
-  <a href="https://github.com/AmElmo/loadout/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/AmElmo/loadout/release.yml?style=flat-square&label=build" alt="Build"></a>
+  <a href="https://github.com/AmElmo/loadout/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License"></a>
+  <a href="https://github.com/AmElmo/loadout/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/AmElmo/loadout/ci.yml?style=flat-square&label=ci" alt="CI"></a>
 </p>
 
 <p align="center">

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,6 @@ Loadout is a desktop application that reads and writes AI CLI configuration file
 
 | Version | Supported |
 | ------- | --------- |
-| 0.1.x   | Yes       |
+| Latest release | Yes |
 
 Only the latest release receives security patches.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "loadout",
   "private": true,
   "version": "0.4.0",
+  "homepage": "https://github.com/AmElmo/loadout",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AmElmo/loadout.git"
+  },
+  "bugs": {
+    "url": "https://github.com/AmElmo/loadout/issues"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/commands/sync.rs
+++ b/src-tauri/src/commands/sync.rs
@@ -1037,25 +1037,10 @@ pub fn install_skill_to_tools(request: InstallSkillRequest) -> Result<WriteResul
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::with_loadout_home;
     use std::fs;
     use std::path::Path;
-    use std::sync::{Mutex, OnceLock};
     use tempfile::{NamedTempFile, TempDir};
-
-    fn with_loadout_home<T>(home: &Path, f: impl FnOnce() -> T) -> T {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        let _guard = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-
-        let previous = std::env::var("LOADOUT_HOME").ok();
-        std::env::set_var("LOADOUT_HOME", home);
-        let result = f();
-        if let Some(prev) = previous {
-            std::env::set_var("LOADOUT_HOME", prev);
-        } else {
-            std::env::remove_var("LOADOUT_HOME");
-        }
-        result
-    }
 
     #[cfg(unix)]
     fn create_dir_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@ mod converters;
 pub mod helpers;
 mod parsers;
 mod scanners;
+#[cfg(test)]
+pub(crate) mod test_utils;
 mod workspace;
 mod writers;
 

--- a/src-tauri/src/scanners/repos.rs
+++ b/src-tauri/src/scanners/repos.rs
@@ -354,24 +354,9 @@ pub fn scan_repos_without_rules(max_depth: u32) -> Result<RepoScanResult, String
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::with_loadout_home;
     use std::fs;
-    use std::sync::{Mutex, OnceLock};
     use tempfile::TempDir;
-
-    fn with_loadout_home<T>(home: &Path, f: impl FnOnce() -> T) -> T {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        let _guard = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-
-        let previous = std::env::var("LOADOUT_HOME").ok();
-        std::env::set_var("LOADOUT_HOME", home);
-        let result = f();
-        if let Some(prev) = previous {
-            std::env::set_var("LOADOUT_HOME", prev);
-        } else {
-            std::env::remove_var("LOADOUT_HOME");
-        }
-        result
-    }
 
     #[test]
     fn test_has_any_rules_with_claude_md() {

--- a/src-tauri/src/scanners/workspaces.rs
+++ b/src-tauri/src/scanners/workspaces.rs
@@ -378,24 +378,9 @@ pub fn discover_workspaces(max_depth: u32) -> Result<DiscoveryResult, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::with_loadout_home;
     use std::fs;
-    use std::sync::{Mutex, OnceLock};
     use tempfile::TempDir;
-
-    fn with_loadout_home<T>(home: &std::path::Path, f: impl FnOnce() -> T) -> T {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        let _guard = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-
-        let previous = std::env::var("LOADOUT_HOME").ok();
-        std::env::set_var("LOADOUT_HOME", home);
-        let result = f();
-        if let Some(prev) = previous {
-            std::env::set_var("LOADOUT_HOME", prev);
-        } else {
-            std::env::remove_var("LOADOUT_HOME");
-        }
-        result
-    }
 
     #[test]
     fn test_workspace_signals_tool_count() {

--- a/src-tauri/src/test_utils.rs
+++ b/src-tauri/src/test_utils.rs
@@ -1,0 +1,28 @@
+use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+pub(crate) fn with_loadout_home<T>(home: &Path, f: impl FnOnce() -> T) -> T {
+    let _guard = env_lock().lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let previous = std::env::var("LOADOUT_HOME").ok();
+    std::env::set_var("LOADOUT_HOME", home);
+
+    let result = catch_unwind(AssertUnwindSafe(f));
+
+    if let Some(prev) = previous {
+        std::env::set_var("LOADOUT_HOME", prev);
+    } else {
+        std::env::remove_var("LOADOUT_HOME");
+    }
+
+    match result {
+        Ok(value) => value,
+        Err(payload) => resume_unwind(payload),
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,6 @@ function App() {
     mainRef.current?.scrollTo(0, 0);
     // Clear selected repo when navigating away from repos tab
     if (activeTab !== "repos") {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset repo selection on tab change
       setSelectedRepo(null);
     }
   }, [activeTab, setSelectedRepo]);

--- a/src/hooks/useInfiniteList.ts
+++ b/src/hooks/useInfiniteList.ts
@@ -1,14 +1,28 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useReducer, useEffect, useRef, useCallback } from "react";
 
 const DEFAULT_BATCH_SIZE = 20;
 
+type InfiniteListAction =
+  | { type: "reset"; batchSize: number }
+  | { type: "load-more"; batchSize: number; itemCount: number };
+
+function infiniteListReducer(visibleCount: number, action: InfiniteListAction) {
+  switch (action.type) {
+    case "reset":
+      return action.batchSize;
+    case "load-more":
+      return Math.min(visibleCount + action.batchSize, action.itemCount);
+    default:
+      return visibleCount;
+  }
+}
+
 export function useInfiniteList<T>(items: T[], batchSize = DEFAULT_BATCH_SIZE) {
-  const [visibleCount, setVisibleCount] = useState(batchSize);
+  const [visibleCount, dispatch] = useReducer(infiniteListReducer, batchSize);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
-  // Reset visible count when items change (new search/filter)
   useEffect(() => {
-    setVisibleCount(batchSize);
+    dispatch({ type: "reset", batchSize });
   }, [items, batchSize]);
 
   const sentinelCallback = useCallback(
@@ -26,7 +40,7 @@ export function useInfiniteList<T>(items: T[], batchSize = DEFAULT_BATCH_SIZE) {
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting) {
-          setVisibleCount((prev) => Math.min(prev + batchSize, items.length));
+          dispatch({ type: "load-more", batchSize, itemCount: items.length });
         }
       },
       { rootMargin: "200px" }
@@ -34,7 +48,6 @@ export function useInfiniteList<T>(items: T[], batchSize = DEFAULT_BATCH_SIZE) {
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- sentinelRef.current is set via callback ref
   }, [items.length, batchSize]);
 
   const visibleItems = items.slice(0, visibleCount);

--- a/src/pages/Context.tsx
+++ b/src/pages/Context.tsx
@@ -13,6 +13,11 @@ import { Button } from "@/components/ui/button";
 import type { MCPItem, MCPToolsResult, SourceTool } from "@/types";
 import { ToolLogo } from "@/components/ToolLogo";
 import { ALL_TOOLS, TOOL_CONFIG } from "@/config/tools";
+import type { PromptFile, SkillItem } from "@/types";
+
+const EMPTY_PROMPTS: PromptFile[] = [];
+const EMPTY_SKILLS: SkillItem[] = [];
+const EMPTY_MCPS: MCPItem[] = [];
 
 function buildToolFilters(tools: SourceTool[]) {
   return tools.map((id) => ({
@@ -22,7 +27,6 @@ function buildToolFilters(tools: SourceTool[]) {
 }
 
 export function Context() {
-
   const [activeTool, setActiveTool] = useState<SourceTool>("claude");
   const [showHelp, setShowHelp] = useState(false);
 
@@ -144,9 +148,9 @@ export function Context() {
     }
   };
 
-  const prompts = rulesResult?.prompts ?? [];
-  const skills = skillsResult?.skills ?? [];
-  const mcpsList = mcps ?? [];
+  const prompts = rulesResult?.prompts ?? EMPTY_PROMPTS;
+  const skills = skillsResult?.skills ?? EMPTY_SKILLS;
+  const mcpsList = mcps ?? EMPTY_MCPS;
 
   const availableTools = useMemo(() => {
     const tools = new Set<SourceTool>();

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -28,6 +28,12 @@ import type {
 import { ToolLogo } from "@/components/ToolLogo";
 import { ALL_TOOLS, toolLabel, toolTextColor, toolAccentColor } from "@/config/tools";
 
+const EMPTY_MCPS: MCPItem[] = [];
+const EMPTY_SKILLS: SkillItem[] = [];
+const EMPTY_RULES: PromptFile[] = [];
+const EMPTY_HOOKS: HookItem[] = [];
+const EMPTY_WORKSPACES: DiscoveredWorkspace[] = [];
+
 // ---------------------------------------------------------------------------
 // Stat Card
 // ---------------------------------------------------------------------------
@@ -285,11 +291,16 @@ export function Home() {
     staleTime: 5 * 60 * 1000,
   });
 
-  const mcpsList = mcps ?? [];
-  const skills = skillsResult?.skills ?? [];
-  const rules = (rulesResult?.prompts ?? []).filter((r) => r.exists);
-  const hooks = hooksResult?.hooks ?? [];
-  const workspaces = (discovery?.workspaces ?? []).filter(isRealWorkspace);
+  const mcpsList = mcps ?? EMPTY_MCPS;
+  const skills = skillsResult?.skills ?? EMPTY_SKILLS;
+  const prompts = rulesResult?.prompts ?? EMPTY_RULES;
+  const rules = useMemo(() => prompts.filter((r) => r.exists), [prompts]);
+  const hooks = hooksResult?.hooks ?? EMPTY_HOOKS;
+  const discoveredWorkspaces = discovery?.workspaces ?? EMPTY_WORKSPACES;
+  const workspaces = useMemo(
+    () => discoveredWorkspaces.filter(isRealWorkspace),
+    [discoveredWorkspaces]
+  );
 
   const error = mcpsError || skillsError || rulesError || hooksError;
 


### PR DESCRIPTION
This tightens the repo for public launch by fixing README trust signals, security/version metadata, package metadata, CI triggering, and changelog polish.
It also removes React lint debt by stabilizing list state and memo dependencies on the Home and Context pages.
On the Rust side, it fixes flaky parallel tests by centralizing `LOADOUT_HOME` test isolation into a shared helper used across modules.
Validation passed with `pnpm lint`, `pnpm build`, repeated `cargo test`, `cargo test -- --test-threads=1`, and `cargo clippy --all-targets -- -D warnings`.