### PR TITLE
ci: add rust-cache to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: |
+            src-tauri -> target
       - name: Install Linux dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,16 +48,11 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
-      - name: Cache Rust build artifacts
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: rust-${{ matrix.target }}-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            rust-${{ matrix.target }}-
+          key: ${{ matrix.target }}
+          workspaces: |
+            src-tauri -> target
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
This updates Rust caching in both CI workflows.

In .github/workflows/ci.yml, it adds Swatinem/rust-cache for the backend job with the src-tauri workspace target mapping.
In .github/workflows/release.yml, it replaces the manual actions/cache Rust block with Swatinem/rust-cache using the matrix target key and the same src-tauri workspace mapping.
Closes #109.